### PR TITLE
feat(http): Allow registering global middleware

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global code owners
+* @imdhemy

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@koala-ts/framework",
   "main": "dist/index.js",
   "type": "module",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "A NodeJS framework for lazy developers",
   "keywords": [
     "koala",

--- a/src/Application/ApplicationFactory.test.ts
+++ b/src/Application/ApplicationFactory.test.ts
@@ -138,7 +138,7 @@ describe('Application', () => {
 });
 
 describe('Global Middleware', () => {
-  test('it should register configured global middleware', () => {
+  test('it should register configured global middleware', async () => {
     const middlewareFn = vi.fn();
     const config = {
       controllers: [],
@@ -146,7 +146,7 @@ describe('Global Middleware', () => {
     };
     const testAgent = createTestAgent(config as KoalaConfig);
 
-    testAgent.get('/');
+    await testAgent.get('/');
 
     expect(middlewareFn).toHaveBeenCalled();
   });

--- a/src/Application/ApplicationFactory.test.ts
+++ b/src/Application/ApplicationFactory.test.ts
@@ -140,11 +140,11 @@ describe('Application', () => {
 describe('Global Middleware', () => {
   test('it should register configured global middleware', () => {
     const middlewareFn = vi.fn();
-    const config: KoalaConfig = {
+    const config = {
       controllers: [],
       globalMiddleware: [middlewareFn],
     };
-    const testAgent = createTestAgent(config);
+    const testAgent = createTestAgent(config as KoalaConfig);
 
     testAgent.get('/');
 

--- a/src/Application/ApplicationFactory.test.ts
+++ b/src/Application/ApplicationFactory.test.ts
@@ -1,7 +1,7 @@
 import Koa from 'koa';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { create } from '@/Application/ApplicationFactory';
-import { koalaDefaultConfig } from '@/Config';
+import { KoalaConfig, koalaDefaultConfig } from '@/Config';
 import type { HttpScope, NextMiddleware, UploadedFile } from '@/Http';
 import { Route } from '@/Routing';
 import { createTestAgent, TestAgent } from '@/Testing';
@@ -134,5 +134,20 @@ describe('Application', () => {
     const response = await agent.post('/upload').attach('avatar', 'tests/fixtures/avatar.png');
 
     expect(response.text).toBe('avatar.png');
+  });
+});
+
+describe('Global Middleware', () => {
+  test('it should register configured global middleware', () => {
+    const middlewareFn = vi.fn();
+    const config: KoalaConfig = {
+      controllers: [],
+      globalMiddleware: [middlewareFn],
+    };
+    const testAgent = createTestAgent(config);
+
+    testAgent.get('/');
+
+    expect(middlewareFn).toHaveBeenCalled();
   });
 });

--- a/src/Application/ApplicationFactory.ts
+++ b/src/Application/ApplicationFactory.ts
@@ -4,14 +4,15 @@ import { koaBody } from 'koa-body';
 import { type Application } from './types';
 import { extendResponse } from '@/Application/Response';
 import { type KoalaConfig } from '@/Config';
-import { type HttpScope } from '@/Http';
+import { type HttpMiddleware, type HttpScope } from '@/Http';
 import { getRoutes } from '@/Routing';
 
-export function create(_: KoalaConfig): Application {
+export function create(config: KoalaConfig): Application {
   const app = new Koa() as Application;
   app.scope = app.context;
 
   app.use(extendResponse);
+  if (undefined !== config.globalMiddleware) registerGlobalMiddleware(app, config.globalMiddleware);
   app.use(createRouter().routes());
 
   return app;
@@ -30,4 +31,10 @@ function createRouter(): Router {
   }
 
   return router;
+}
+
+function registerGlobalMiddleware(app: Application, middleware: HttpMiddleware[]): void {
+  for (const mw of middleware) {
+    app.use(mw);
+  }
 }

--- a/src/Application/ApplicationFactory.ts
+++ b/src/Application/ApplicationFactory.ts
@@ -11,6 +11,13 @@ export function create(_: KoalaConfig): Application {
   const app = new Koa() as Application;
   app.scope = app.context;
 
+  app.use(extendResponse);
+  app.use(createRouter().routes());
+
+  return app;
+}
+
+function createRouter(): Router {
   const router = new Router();
 
   for (const route of getRoutes()) {
@@ -22,8 +29,5 @@ export function create(_: KoalaConfig): Application {
     }
   }
 
-  app.use(extendResponse);
-  app.use(router.routes());
-
-  return app;
+  return router;
 }

--- a/src/Config/types.ts
+++ b/src/Config/types.ts
@@ -1,5 +1,8 @@
+import { type HttpMiddleware } from '@/Http';
+
 export type Controller = new(...args: unknown[]) => unknown;
 
 export interface KoalaConfig {
   controllers: Controller[];
+  globalMiddleware?: HttpMiddleware[];
 }


### PR DESCRIPTION
This PR allows registering global middleware. Closes #62 

The `KoalaConfig` type is extended by an optional array `globalMiddleware`.

```diff
export interface KoalaConfig {
  controllers: Controller[];
++  globalMiddleware?: HttpMiddleware[];
}
```

The configured middleware will be registered in order and before all routes.