### PR TITLE
feat(validation): add validator component

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,4 @@ export * from '@/Routing';
 export * from '@/Security';
 export * from '@/Testing';
 export * from '@/serializer';
+export * from '@/validator';

--- a/src/validator/constraints/basic/not-blank.test.ts
+++ b/src/validator/constraints/basic/not-blank.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { notBlank } from './not-blank';
 import type { ConstraintContext } from '../../types';
+import { notBlank } from './not-blank';
 
-describe('notBlank (unit)', () => {
+describe('notBlank', () => {
   it.each([
     { value: '', label: 'empty string' },
     { value: null, label: 'null' },
@@ -15,7 +15,7 @@ describe('notBlank (unit)', () => {
       value,
       constraint: 'notBlank',
       options: {},
-      applyConstraints: () => [],
+      runNestedRules: () => [],
     };
 
     const violations = notBlank(value, context);
@@ -36,7 +36,7 @@ describe('notBlank (unit)', () => {
       value: '',
       constraint: 'notBlank',
       options: { message: 'Required' },
-      applyConstraints: () => [],
+      runNestedRules: () => [],
     };
 
     const violations = notBlank('', context);
@@ -57,7 +57,7 @@ describe('notBlank (unit)', () => {
       value: '   ',
       constraint: 'notBlank',
       options: { normalizer: (value: string) => value.trim() },
-      applyConstraints: () => [],
+      runNestedRules: () => [],
     };
 
     const violations = notBlank('   ', context);
@@ -81,7 +81,7 @@ describe('notBlank (unit)', () => {
       value,
       constraint: 'notBlank',
       options: {},
-      applyConstraints: () => [],
+      runNestedRules: () => [],
     };
 
     const violations = notBlank(value, context);

--- a/src/validator/constraints/basic/not-blank.test.ts
+++ b/src/validator/constraints/basic/not-blank.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { notBlank } from './not-blank';
+import type { ConstraintContext } from '../../types';
+
+describe('notBlank (unit)', () => {
+  it.each([
+    { value: '', label: 'empty string' },
+    { value: null, label: 'null' },
+    { value: undefined, label: 'undefined' },
+    { value: [], label: 'empty array' },
+  ])('returns a violation when value is $label and no options are provided', ({ value }) => {
+    const context: ConstraintContext = {
+      path: 'name',
+      root: { name: value },
+      value,
+      constraint: 'notBlank',
+      options: {},
+    };
+
+    const violations = notBlank(value, context);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toEqual({
+      path: 'name',
+      constraint: 'notBlank',
+      message: 'This value should not be blank.',
+      value,
+    });
+  });
+
+  it('uses a custom message when provided', () => {
+    const context: ConstraintContext = {
+      path: 'name',
+      root: { name: '' },
+      value: '',
+      constraint: 'notBlank',
+      options: { message: 'Required' },
+    };
+
+    const violations = notBlank('', context);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toEqual({
+      path: 'name',
+      constraint: 'notBlank',
+      message: 'Required',
+      value: '',
+    });
+  });
+
+  it('normalizes string values before checking blankness', () => {
+    const context: ConstraintContext = {
+      path: 'name',
+      root: { name: '   ' },
+      value: '   ',
+      constraint: 'notBlank',
+      options: { normalizer: (value: string) => value.trim() },
+    };
+
+    const violations = notBlank('   ', context);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toEqual({
+      path: 'name',
+      constraint: 'notBlank',
+      message: 'This value should not be blank.',
+      value: '   ',
+    });
+  });
+});

--- a/src/validator/constraints/basic/not-blank.test.ts
+++ b/src/validator/constraints/basic/not-blank.test.ts
@@ -70,4 +70,22 @@ describe('notBlank (unit)', () => {
       value: '   ',
     });
   });
+
+  it.each([
+    { value: 'valid', label: 'non-empty string' },
+    { value: ['value'], label: 'non-empty array' },
+  ])('returns no violations for $label', ({ value }) => {
+    const context: ConstraintContext = {
+      path: 'name',
+      root: { name: value },
+      value,
+      constraint: 'notBlank',
+      options: {},
+      applyConstraints: () => [],
+    };
+
+    const violations = notBlank(value, context);
+
+    expect(violations).toHaveLength(0);
+  });
 });

--- a/src/validator/constraints/basic/not-blank.test.ts
+++ b/src/validator/constraints/basic/not-blank.test.ts
@@ -15,6 +15,7 @@ describe('notBlank (unit)', () => {
       value,
       constraint: 'notBlank',
       options: {},
+      applyConstraints: () => [],
     };
 
     const violations = notBlank(value, context);
@@ -35,6 +36,7 @@ describe('notBlank (unit)', () => {
       value: '',
       constraint: 'notBlank',
       options: { message: 'Required' },
+      applyConstraints: () => [],
     };
 
     const violations = notBlank('', context);
@@ -55,6 +57,7 @@ describe('notBlank (unit)', () => {
       value: '   ',
       constraint: 'notBlank',
       options: { normalizer: (value: string) => value.trim() },
+      applyConstraints: () => [],
     };
 
     const violations = notBlank('   ', context);

--- a/src/validator/constraints/basic/not-blank.ts
+++ b/src/validator/constraints/basic/not-blank.ts
@@ -1,0 +1,29 @@
+import type { ConstraintContext, Violation } from '../../types';
+
+const DEFAULT_MESSAGE = 'This value should not be blank.';
+
+export function notBlank(value: unknown, context: ConstraintContext): Violation[] {
+  const message = typeof context.options.message === 'string' ? context.options.message : DEFAULT_MESSAGE;
+
+  const normalizedValue =
+    typeof value === 'string' && typeof context.options.normalizer === 'function'
+      ? context.options.normalizer(value)
+      : value;
+
+  if (isBlank(normalizedValue)) {
+    return [
+      {
+        path: context.path,
+        constraint: context.constraint,
+        message,
+        value,
+      },
+    ];
+  }
+
+  return [];
+}
+
+function isBlank(value: unknown): boolean {
+  return value === '' || value === null || value === undefined || (Array.isArray(value) && value.length === 0);
+}

--- a/src/validator/constraints/basic/not-blank.ts
+++ b/src/validator/constraints/basic/not-blank.ts
@@ -2,13 +2,17 @@ import type { ConstraintContext, Violation } from '../../types';
 
 const DEFAULT_MESSAGE = 'This value should not be blank.';
 
+type NotBlankOptions = {
+  message?: string;
+  normalizer?: (value: string) => string;
+};
+
 export function notBlank(value: unknown, context: ConstraintContext): Violation[] {
-  const message = typeof context.options.message === 'string' ? context.options.message : DEFAULT_MESSAGE;
+  const options = context.options as NotBlankOptions;
+  const message = options.message ?? DEFAULT_MESSAGE;
 
   const normalizedValue =
-    typeof value === 'string' && typeof context.options.normalizer === 'function'
-      ? context.options.normalizer(value)
-      : value;
+    typeof value === 'string' && typeof options.normalizer === 'function' ? options.normalizer(value) : value;
 
   if (isBlank(normalizedValue)) {
     return [

--- a/src/validator/constraints/index.ts
+++ b/src/validator/constraints/index.ts
@@ -1,0 +1,10 @@
+import { notBlank } from '@/validator/constraints/basic/not-blank';
+import { email } from '@/validator/constraints/string/email';
+
+export const builtInConstraints = {
+  // Basic
+  notBlank,
+
+  // String
+  email,
+};

--- a/src/validator/constraints/other/compound.integration.test.ts
+++ b/src/validator/constraints/other/compound.integration.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { createValidator } from '../../validator';
+import { notBlank } from '../basic/not-blank';
+import { email } from '../string/email';
+import { compound } from './compound';
+
+describe('compound (integration)', () => {
+  it('applies nested constraints to the same value', () => {
+    const requiredEmail = compound(['notBlank', 'email']);
+
+    const validate = createValidator({
+      constraints: {
+        requiredEmail,
+        notBlank,
+        email,
+      },
+    });
+
+    const rules = {
+      userEmail: ['requiredEmail'],
+    };
+
+    const violations = validate({ userEmail: '' }, rules);
+
+    expect(violations).toHaveLength(2);
+    expect(violations[0]).toEqual({
+      path: 'userEmail',
+      constraint: 'notBlank',
+      message: 'This value should not be blank.',
+      value: '',
+    });
+    expect(violations[1]).toEqual({
+      path: 'userEmail',
+      constraint: 'email',
+      message: 'This value is not a valid email address.',
+      value: '',
+    });
+  });
+
+  it('accepts object rule definitions with options', () => {
+    const requiredEmail = compound(['notBlank', { email: { message: 'Invalid email' } }]);
+
+    const validate = createValidator({
+      constraints: {
+        requiredEmail,
+        notBlank,
+        email,
+      },
+    });
+
+    const rules = {
+      userEmail: ['requiredEmail'],
+    };
+
+    const violations = validate({ userEmail: '' }, rules);
+
+    expect(violations).toHaveLength(2);
+    expect(violations[0]).toEqual({
+      path: 'userEmail',
+      constraint: 'notBlank',
+      message: 'This value should not be blank.',
+      value: '',
+    });
+    expect(violations[1]).toEqual({
+      path: 'userEmail',
+      constraint: 'email',
+      message: 'Invalid email',
+      value: '',
+    });
+  });
+});

--- a/src/validator/constraints/other/compound.integration.test.ts
+++ b/src/validator/constraints/other/compound.integration.test.ts
@@ -68,4 +68,23 @@ describe('compound (integration)', () => {
       value: '',
     });
   });
+
+  it('uses the nested value passed via applyConstraints', () => {
+    const requiredEmail = compound([{ email: { normalizer: (value: string) => value.trim() } }]);
+
+    const validate = createValidator({
+      constraints: {
+        requiredEmail,
+        email,
+      },
+    });
+
+    const rules = {
+      userEmail: ['requiredEmail'],
+    };
+
+    const violations = validate({ userEmail: ' user@example.com ' }, rules);
+
+    expect(violations).toHaveLength(0);
+  });
 });

--- a/src/validator/constraints/other/compound.test.ts
+++ b/src/validator/constraints/other/compound.test.ts
@@ -3,7 +3,7 @@ import { compound } from './compound';
 import type { ConstraintContext, Violation } from '../../types';
 
 describe('compound', () => {
-  it('applies nested constraints using applyConstraints', () => {
+  it('creates a constraint that applies nested constraints from arrays', () => {
     const applyConstraints = vi.fn((): Violation[] => [
       {
         path: 'user',
@@ -13,28 +13,59 @@ describe('compound', () => {
       },
     ]);
 
-    const nestedConstraints = {
-      notBlank: {},
-    };
+    const nestedConstraints = ['notBlank'];
 
     const context: ConstraintContext = {
       path: 'user',
       root: { user: '' },
       value: '',
-      constraint: 'compound',
-      options: { constraints: nestedConstraints },
+      constraint: 'requiredEmail',
+      options: {},
       applyConstraints,
     };
 
-    const violations = compound('', context);
+    const requiredEmail = compound(nestedConstraints);
+    const violations = requiredEmail('', context);
 
-    expect(applyConstraints).toHaveBeenCalledWith('', nestedConstraints, 'user');
+    expect(applyConstraints).toHaveBeenCalledWith('', ['notBlank'], 'user');
     expect(violations).toHaveLength(1);
     expect(violations[0]).toEqual({
       path: 'user',
       constraint: 'notBlank',
       message: 'Required',
       value: '',
+    });
+  });
+
+  it('creates a constraint that applies nested constraints from objects', () => {
+    const applyConstraints = vi.fn((): Violation[] => [
+      {
+        path: 'user',
+        constraint: 'notNull',
+        message: 'Required',
+        value: null,
+      },
+    ]);
+
+    const context: ConstraintContext = {
+      path: 'user',
+      root: { user: null },
+      value: null,
+      constraint: 'requiredEmail',
+      options: {},
+      applyConstraints,
+    };
+
+    const requiredEmail = compound({ notNull: {} });
+    const violations = requiredEmail(null, context);
+
+    expect(applyConstraints).toHaveBeenCalledWith(null, { notNull: {} }, 'user');
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toEqual({
+      path: 'user',
+      constraint: 'notNull',
+      message: 'Required',
+      value: null,
     });
   });
 });

--- a/src/validator/constraints/other/compound.test.ts
+++ b/src/validator/constraints/other/compound.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
-import { compound } from './compound';
 import type { ConstraintContext, Violation } from '../../types';
+import { compound } from './compound';
 
 describe('compound', () => {
   it('creates a constraint that applies nested constraints from arrays', () => {
@@ -21,7 +21,7 @@ describe('compound', () => {
       value: '',
       constraint: 'requiredEmail',
       options: {},
-      applyConstraints,
+      runNestedRules: applyConstraints,
     };
 
     const requiredEmail = compound(nestedConstraints);
@@ -53,7 +53,7 @@ describe('compound', () => {
       value: null,
       constraint: 'requiredEmail',
       options: {},
-      applyConstraints,
+      runNestedRules: applyConstraints,
     };
 
     const requiredEmail = compound({ notNull: {} });

--- a/src/validator/constraints/other/compound.test.ts
+++ b/src/validator/constraints/other/compound.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+import { compound } from './compound';
+import type { ConstraintContext, Violation } from '../../types';
+
+describe('compound', () => {
+  it('applies nested constraints using applyConstraints', () => {
+    const applyConstraints = vi.fn((): Violation[] => [
+      {
+        path: 'user',
+        constraint: 'notBlank',
+        message: 'Required',
+        value: '',
+      },
+    ]);
+
+    const nestedConstraints = {
+      notBlank: {},
+    };
+
+    const context: ConstraintContext = {
+      path: 'user',
+      root: { user: '' },
+      value: '',
+      constraint: 'compound',
+      options: { constraints: nestedConstraints },
+      applyConstraints,
+    };
+
+    const violations = compound('', context);
+
+    expect(applyConstraints).toHaveBeenCalledWith('', nestedConstraints, 'user');
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toEqual({
+      path: 'user',
+      constraint: 'notBlank',
+      message: 'Required',
+      value: '',
+    });
+  });
+});

--- a/src/validator/constraints/other/compound.ts
+++ b/src/validator/constraints/other/compound.ts
@@ -1,16 +1,11 @@
 import type { ConstraintContext, FieldRules, Violation } from '../../types';
 
-type CompoundOptions = {
-  constraints?: FieldRules;
-};
+export function compound(rules: FieldRules) {
+  return function compoundConstraint(value: unknown, context: ConstraintContext): Violation[] {
+    if (!rules || typeof rules !== 'object') {
+      throw new Error('Compound constraint requires constraints to be defined.');
+    }
 
-export function compound(value: unknown, context: ConstraintContext): Violation[] {
-  const options = context.options as CompoundOptions;
-  const constraints = options.constraints;
-
-  if (!constraints || typeof constraints !== 'object') {
-    throw new Error('Compound constraint requires constraints to be defined.');
-  }
-
-  return context.applyConstraints(value, constraints, context.path);
+    return context.applyConstraints(value, rules, context.path);
+  };
 }

--- a/src/validator/constraints/other/compound.ts
+++ b/src/validator/constraints/other/compound.ts
@@ -2,6 +2,6 @@ import type { ConstraintContext, FieldRules, Violation } from '../../types';
 
 export function compound(rules: FieldRules) {
   return function compoundConstraint(value: unknown, context: ConstraintContext): Violation[] {
-    return context.applyConstraints(value, rules, context.path);
+    return context.runNestedRules(value, rules, context.path);
   };
 }

--- a/src/validator/constraints/other/compound.ts
+++ b/src/validator/constraints/other/compound.ts
@@ -1,0 +1,16 @@
+import type { ConstraintContext, FieldRules, Violation } from '../../types';
+
+type CompoundOptions = {
+  constraints?: FieldRules;
+};
+
+export function compound(value: unknown, context: ConstraintContext): Violation[] {
+  const options = context.options as CompoundOptions;
+  const constraints = options.constraints;
+
+  if (!constraints || typeof constraints !== 'object') {
+    throw new Error('Compound constraint requires constraints to be defined.');
+  }
+
+  return context.applyConstraints(value, constraints, context.path);
+}

--- a/src/validator/constraints/other/compound.ts
+++ b/src/validator/constraints/other/compound.ts
@@ -2,10 +2,6 @@ import type { ConstraintContext, FieldRules, Violation } from '../../types';
 
 export function compound(rules: FieldRules) {
   return function compoundConstraint(value: unknown, context: ConstraintContext): Violation[] {
-    if (!rules || typeof rules !== 'object') {
-      throw new Error('Compound constraint requires constraints to be defined.');
-    }
-
     return context.applyConstraints(value, rules, context.path);
   };
 }

--- a/src/validator/constraints/string/email.test.ts
+++ b/src/validator/constraints/string/email.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { email } from './email';
 import type { ConstraintContext } from '../../types';
+import { email } from './email';
 
 describe('email', () => {
   it('rejects invalid email by default', () => {
@@ -10,7 +10,7 @@ describe('email', () => {
       value: 'invalid',
       constraint: 'email',
       options: {},
-      applyConstraints: () => [],
+      runNestedRules: () => [],
     };
 
     const violations = email('invalid', context);
@@ -31,7 +31,7 @@ describe('email', () => {
       value: 'user@example.com',
       constraint: 'email',
       options: {},
-      applyConstraints: () => [],
+      runNestedRules: () => [],
     };
 
     const violations = email('user@example.com', context);
@@ -46,7 +46,7 @@ describe('email', () => {
       value: 'user@localhost',
       constraint: 'email',
       options: {},
-      applyConstraints: () => [],
+      runNestedRules: () => [],
     };
 
     const violations = email('user@localhost', context);
@@ -67,7 +67,7 @@ describe('email', () => {
       value: ' USER@EXAMPLE.COM ',
       constraint: 'email',
       options: { normalizer: (value: string) => value.trim().toLowerCase() },
-      applyConstraints: () => [],
+      runNestedRules: () => [],
     };
 
     const violations = email(' USER@EXAMPLE.COM ', context);
@@ -82,7 +82,7 @@ describe('email', () => {
       value: 'invalid',
       constraint: 'email',
       options: { message: 'Invalid email' },
-      applyConstraints: () => [],
+      runNestedRules: () => [],
     };
 
     const violations = email('invalid', context);
@@ -103,7 +103,7 @@ describe('email', () => {
       value: 42,
       constraint: 'email',
       options: {},
-      applyConstraints: () => [],
+      runNestedRules: () => [],
     };
 
     const violations = email(42, context);
@@ -124,7 +124,7 @@ describe('email', () => {
       value: 42,
       constraint: 'email',
       options: { message: 'Invalid email' },
-      applyConstraints: () => [],
+      runNestedRules: () => [],
     };
 
     const violations = email(42, context);

--- a/src/validator/constraints/string/email.test.ts
+++ b/src/validator/constraints/string/email.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { email } from './email';
+import type { ConstraintContext } from '../../types';
+
+describe('email', () => {
+  it('rejects invalid email by default', () => {
+    const context: ConstraintContext = {
+      path: 'email',
+      root: { email: 'invalid' },
+      value: 'invalid',
+      constraint: 'email',
+      options: {},
+      applyConstraints: () => [],
+    };
+
+    const violations = email('invalid', context);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toEqual({
+      path: 'email',
+      constraint: 'email',
+      message: 'This value is not a valid email address.',
+      value: 'invalid',
+    });
+  });
+
+  it('accepts valid email by default', () => {
+    const context: ConstraintContext = {
+      path: 'email',
+      root: { email: 'user@example.com' },
+      value: 'user@example.com',
+      constraint: 'email',
+      options: {},
+      applyConstraints: () => [],
+    };
+
+    const violations = email('user@example.com', context);
+
+    expect(violations).toHaveLength(0);
+  });
+
+  it('rejects localhost domains by default', () => {
+    const context: ConstraintContext = {
+      path: 'email',
+      root: { email: 'user@localhost' },
+      value: 'user@localhost',
+      constraint: 'email',
+      options: {},
+      applyConstraints: () => [],
+    };
+
+    const violations = email('user@localhost', context);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toEqual({
+      path: 'email',
+      constraint: 'email',
+      message: 'This value is not a valid email address.',
+      value: 'user@localhost',
+    });
+  });
+
+  it('normalizes values before validation', () => {
+    const context: ConstraintContext = {
+      path: 'email',
+      root: { email: ' USER@EXAMPLE.COM ' },
+      value: ' USER@EXAMPLE.COM ',
+      constraint: 'email',
+      options: { normalizer: (value: string) => value.trim().toLowerCase() },
+      applyConstraints: () => [],
+    };
+
+    const violations = email(' USER@EXAMPLE.COM ', context);
+
+    expect(violations).toHaveLength(0);
+  });
+
+  it('uses a custom message when provided', () => {
+    const context: ConstraintContext = {
+      path: 'email',
+      root: { email: 'invalid' },
+      value: 'invalid',
+      constraint: 'email',
+      options: { message: 'Invalid email' },
+      applyConstraints: () => [],
+    };
+
+    const violations = email('invalid', context);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toEqual({
+      path: 'email',
+      constraint: 'email',
+      message: 'Invalid email',
+      value: 'invalid',
+    });
+  });
+});

--- a/src/validator/constraints/string/email.test.ts
+++ b/src/validator/constraints/string/email.test.ts
@@ -95,4 +95,46 @@ describe('email', () => {
       value: 'invalid',
     });
   });
+
+  it('rejects non-string values with the default message', () => {
+    const context: ConstraintContext = {
+      path: 'email',
+      root: { email: 42 },
+      value: 42,
+      constraint: 'email',
+      options: {},
+      applyConstraints: () => [],
+    };
+
+    const violations = email(42, context);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toEqual({
+      path: 'email',
+      constraint: 'email',
+      message: 'This value is not a valid email address.',
+      value: 42,
+    });
+  });
+
+  it('uses a custom message for non-string values', () => {
+    const context: ConstraintContext = {
+      path: 'email',
+      root: { email: 42 },
+      value: 42,
+      constraint: 'email',
+      options: { message: 'Invalid email' },
+      applyConstraints: () => [],
+    };
+
+    const violations = email(42, context);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toEqual({
+      path: 'email',
+      constraint: 'email',
+      message: 'Invalid email',
+      value: 42,
+    });
+  });
 });

--- a/src/validator/constraints/string/email.ts
+++ b/src/validator/constraints/string/email.ts
@@ -1,0 +1,40 @@
+import type { ConstraintContext, Violation } from '../../types';
+
+const DEFAULT_MESSAGE = 'This value is not a valid email address.';
+
+type EmailOptions = {
+  message?: string;
+  normalizer?: (value: string) => string;
+};
+
+const strictEmailRegex = /^[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+$/;
+
+export function email(value: unknown, context: ConstraintContext): Violation[] {
+  if (typeof value !== 'string') {
+    return [
+      {
+        path: context.path,
+        constraint: context.constraint,
+        message: DEFAULT_MESSAGE,
+        value,
+      },
+    ];
+  }
+
+  const options = context.options as EmailOptions;
+  const message = options.message ?? DEFAULT_MESSAGE;
+  const normalized = options.normalizer ? options.normalizer(value) : value;
+
+  if (!strictEmailRegex.test(normalized)) {
+    return [
+      {
+        path: context.path,
+        constraint: context.constraint,
+        message,
+        value,
+      },
+    ];
+  }
+
+  return [];
+}

--- a/src/validator/constraints/string/email.ts
+++ b/src/validator/constraints/string/email.ts
@@ -10,19 +10,20 @@ type EmailOptions = {
 const strictEmailRegex = /^[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+$/;
 
 export function email(value: unknown, context: ConstraintContext): Violation[] {
+  const options = context.options as EmailOptions;
+  const message = options.message ?? DEFAULT_MESSAGE;
+
   if (typeof value !== 'string') {
     return [
       {
         path: context.path,
         constraint: context.constraint,
-        message: DEFAULT_MESSAGE,
+        message,
         value,
       },
     ];
   }
 
-  const options = context.options as EmailOptions;
-  const message = options.message ?? DEFAULT_MESSAGE;
   const normalized = options.normalizer ? options.normalizer(value) : value;
 
   if (!strictEmailRegex.test(normalized)) {

--- a/src/validator/errors.ts
+++ b/src/validator/errors.ts
@@ -1,0 +1,6 @@
+export class UnknownConstraintError extends Error {
+  constructor(field: string, constraint: string) {
+    super(`Field "${field}" references unregistered constraint "${constraint}".`);
+    this.name = 'UnknownConstraintError';
+  }
+}

--- a/src/validator/index.ts
+++ b/src/validator/index.ts
@@ -1,0 +1,2 @@
+export * from './validator';
+export * from './types';

--- a/src/validator/index.ts
+++ b/src/validator/index.ts
@@ -1,2 +1,3 @@
 export * from './validator';
 export * from './types';
+export * from './constraints';

--- a/src/validator/types.ts
+++ b/src/validator/types.ts
@@ -5,7 +5,7 @@ export type Violation = {
   value: unknown;
 };
 
-export type ConstraintOptions = Record<string, unknown>;
+export type ConstraintOptions = { groups?: string[] } & Record<string, unknown>;
 export type ConstraintContext = {
   path: string;
   root: unknown;
@@ -18,12 +18,14 @@ export type ConstraintValidator = (value: unknown, context: ConstraintContext) =
 
 export type ConstraintsMap = Record<string, ConstraintValidator>;
 
-export type FieldRules = Record<string, unknown>;
+export type FieldRules = Record<string, ConstraintOptions>;
 
 export type ValidationRules = Record<string, FieldRules>;
 
 export type ValidatorOptions = { constraints: ConstraintsMap };
 
+export type ValidateOptions = { groups?: string[] };
+
 export type Payload = Record<string, unknown>;
 
-export type Validator = (payload: Payload, rules: ValidationRules) => Violation[];
+export type Validator = (payload: Payload, rules: ValidationRules, options?: ValidateOptions) => Violation[];

--- a/src/validator/types.ts
+++ b/src/validator/types.ts
@@ -5,11 +5,13 @@ export type Violation = {
   value: unknown;
 };
 
+export type ConstraintOptions = Record<string, unknown>;
 export type ConstraintContext = {
   path: string;
   root: unknown;
   value: unknown;
   constraint: string;
+  options: ConstraintOptions;
 };
 
 export type ConstraintValidator = (value: unknown, context: ConstraintContext) => Violation[];

--- a/src/validator/types.ts
+++ b/src/validator/types.ts
@@ -18,7 +18,9 @@ export type ConstraintValidator = (value: unknown, context: ConstraintContext) =
 
 export type ConstraintsMap = Record<string, ConstraintValidator>;
 
-export type FieldRules = Record<string, ConstraintOptions>;
+export type FieldRuleEntry = string | Record<string, ConstraintOptions>;
+
+export type FieldRules = Record<string, ConstraintOptions> | FieldRuleEntry[];
 
 export type ValidationRules = Record<string, FieldRules>;
 

--- a/src/validator/types.ts
+++ b/src/validator/types.ts
@@ -12,7 +12,7 @@ export type ConstraintContext = {
   value: unknown;
   constraint: string;
   options: ConstraintOptions;
-  applyConstraints: (value: unknown, rules: FieldRules, path: string) => Violation[];
+  runNestedRules: (value: unknown, rules: FieldRules, path: string) => Violation[];
 };
 
 export type ConstraintValidator = (value: unknown, context: ConstraintContext) => Violation[];

--- a/src/validator/types.ts
+++ b/src/validator/types.ts
@@ -20,7 +20,7 @@ export type FieldRules = Record<string, unknown>;
 
 export type ValidationRules = Record<string, FieldRules>;
 
-export type CreateValidatorOptions = { constraints: ConstraintsMap };
+export type ValidatorOptions = { constraints: ConstraintsMap };
 
 export type Payload = Record<string, unknown>;
 

--- a/src/validator/types.ts
+++ b/src/validator/types.ts
@@ -12,6 +12,7 @@ export type ConstraintContext = {
   value: unknown;
   constraint: string;
   options: ConstraintOptions;
+  applyConstraints: (value: unknown, rules: FieldRules, path: string) => Violation[];
 };
 
 export type ConstraintValidator = (value: unknown, context: ConstraintContext) => Violation[];

--- a/src/validator/types.ts
+++ b/src/validator/types.ts
@@ -1,0 +1,27 @@
+export type Violation = {
+  path: string;
+  message: string;
+  constraint: string;
+  value: unknown;
+};
+
+export type ConstraintContext = {
+  path: string;
+  root: unknown;
+  value: unknown;
+  constraint: string;
+};
+
+export type ConstraintValidator = (value: unknown, context: ConstraintContext) => Violation[];
+
+export type ConstraintsMap = Record<string, ConstraintValidator>;
+
+export type FieldRules = Record<string, unknown>;
+
+export type ValidationRules = Record<string, FieldRules>;
+
+export type CreateValidatorOptions = { constraints: ConstraintsMap };
+
+export type Payload = Record<string, unknown>;
+
+export type Validator = (payload: Payload, rules: ValidationRules) => Violation[];

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -173,6 +173,54 @@ describe('Validator', () => {
 
       expect(violations).toHaveLength(0);
     });
+
+    it('should apply constraints when no groups are provided', () => {
+      const validate = createValidator({
+        constraints: {
+          groupedConstraint,
+        },
+      });
+
+      const rules = {
+        email: {
+          groupedConstraint: {},
+        },
+      };
+
+      const violations = validate({ email: '' }, rules);
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0]).toEqual({
+        path: 'email',
+        constraint: 'groupedConstraint',
+        message: 'Grouped constraint failed',
+        value: '',
+      });
+    });
+
+    it('should apply constraints for the Default group when no groups are provided', () => {
+      const validate = createValidator({
+        constraints: {
+          groupedConstraint,
+        },
+      });
+
+      const rules = {
+        email: {
+          groupedConstraint: { groups: ['Default'] },
+        },
+      };
+
+      const violations = validate({ email: '' }, rules);
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0]).toEqual({
+        path: 'email',
+        constraint: 'groupedConstraint',
+        message: 'Grouped constraint failed',
+        value: '',
+      });
+    });
   });
 });
 

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -115,6 +115,30 @@ describe('Validator', () => {
       });
     });
 
+    it('should accept object rule definitions', () => {
+      const validate = createValidator({
+        constraints: {
+          customConstraint,
+        },
+      });
+
+      const rules = {
+        name: {
+          customConstraint: {},
+        },
+      };
+
+      const violations = validate({ name: '' }, rules);
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0]).toEqual({
+        path: 'name',
+        constraint: 'customConstraint',
+        message: 'Custom constraint validation failed',
+        value: '',
+      });
+    });
+
     it('should accept mixed rule definitions as arrays of strings and option objects', () => {
       const validate = createValidator({
         constraints: {

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -9,9 +9,7 @@ describe('Validator', () => {
       const validate = createValidator({ constraints: {} });
 
       const rules = {
-        name: {
-          required: {},
-        },
+        name: ['required'],
       };
 
       expect(() => validate({ name: 'John' }, rules)).toThrowError(UnknownConstraintError);
@@ -30,9 +28,7 @@ describe('Validator', () => {
       });
 
       const rules = {
-        name: {
-          customConstraint: {},
-        },
+        name: ['customConstraint'],
       };
 
       const violations = validate({ name: '' }, rules);
@@ -53,12 +49,8 @@ describe('Validator', () => {
         },
       });
       const rules = {
-        name: {
-          customConstraint: {},
-        },
-        age: {
-          customConstraint: {},
-        },
+        name: ['customConstraint'],
+        age: ['customConstraint'],
       };
 
       const violations = validate({ name: '', age: 30 }, rules);
@@ -86,9 +78,7 @@ describe('Validator', () => {
       });
 
       const rules = {
-        name: {
-          passedConstraint: {},
-        },
+        name: ['passedConstraint'],
       };
 
       const violations = validate({ name: 'John' }, rules);
@@ -105,10 +95,7 @@ describe('Validator', () => {
       });
 
       const rules = {
-        name: {
-          customConstraint: {},
-          anotherCustomConstraint: {},
-        },
+        name: ['customConstraint', 'anotherCustomConstraint'],
       };
 
       const violations = validate({ name: '' }, rules);
@@ -127,6 +114,35 @@ describe('Validator', () => {
         value: '',
       });
     });
+
+    it('should accept mixed rule definitions as arrays of strings and option objects', () => {
+      const validate = createValidator({
+        constraints: {
+          customConstraint,
+          minLengthConstraint,
+        },
+      });
+
+      const rules = {
+        name: ['customConstraint', { minLengthConstraint: { min: 3 } }],
+      };
+
+      const violations = validate({ name: 'ab' }, rules);
+
+      expect(violations).toHaveLength(2);
+      expect(violations[0]).toEqual({
+        path: 'name',
+        constraint: 'customConstraint',
+        message: 'Custom constraint validation failed',
+        value: 'ab',
+      });
+      expect(violations[1]).toEqual({
+        path: 'name',
+        constraint: 'minLengthConstraint',
+        message: 'Must be at least 3 characters',
+        value: 'ab',
+      });
+    });
   });
 
   describe('Constraint options', () => {
@@ -138,9 +154,7 @@ describe('Validator', () => {
       });
 
       const rules = {
-        name: {
-          minLengthConstraint: { min: 3 },
-        },
+        name: [{ minLengthConstraint: { min: 3 } }],
       };
 
       const violations = validate({ name: 'ab' }, rules);
@@ -164,9 +178,7 @@ describe('Validator', () => {
       });
 
       const rules = {
-        email: {
-          groupedConstraint: { groups: ['create'] },
-        },
+        email: [{ groupedConstraint: { groups: ['create'] } }],
       };
 
       const violations = validate({ email: '' }, rules, { groups: ['update'] });
@@ -182,9 +194,7 @@ describe('Validator', () => {
       });
 
       const rules = {
-        email: {
-          groupedConstraint: {},
-        },
+        email: ['groupedConstraint'],
       };
 
       const violations = validate({ email: '' }, rules);
@@ -206,9 +216,7 @@ describe('Validator', () => {
       });
 
       const rules = {
-        email: {
-          groupedConstraint: { groups: ['Default'] },
-        },
+        email: [{ groupedConstraint: { groups: ['Default'] } }],
       };
 
       const violations = validate({ email: '' }, rules);

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+import type { ConstraintContext, Violation } from './types';
+import { createValidator } from './validator';
+
+describe('Validator', () => {
+  it('should fail when a rule references an undefined constraint', () => {
+    const validate = createValidator({ constraints: {} });
+
+    const rules = {
+      name: {
+        required: {},
+      },
+    };
+
+    expect(() => validate({ name: 'John' }, rules)).toThrowError(
+      'Field "name" references unregistered constraint "required"',
+    );
+  });
+
+  it('should use provided constraints registry to validate rules', () => {
+    const validate = createValidator({
+      constraints: {
+        customConstraint,
+      },
+    });
+
+    const rules = {
+      name: {
+        customConstraint: {},
+      },
+    };
+
+    const violations = validate({ name: '' }, rules);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toEqual({
+      path: 'name',
+      constraint: 'customConstraint',
+      message: 'Custom constraint validation failed',
+      value: '',
+    });
+  });
+
+  it('should map each violation to the invalid field', () => {
+    const validate = createValidator({
+      constraints: {
+        customConstraint,
+      },
+    });
+    const rules = {
+      name: {
+        customConstraint: {},
+      },
+      age: {
+        customConstraint: {},
+      },
+    };
+
+    const violations = validate({ name: '', age: 30 }, rules);
+
+    expect(violations).toHaveLength(2);
+    expect(violations[0]).toEqual({
+      path: 'name',
+      constraint: 'customConstraint',
+      message: 'Custom constraint validation failed',
+      value: '',
+    });
+    expect(violations[1]).toEqual({
+      path: 'age',
+      constraint: 'customConstraint',
+      message: 'Custom constraint validation failed',
+      value: 30,
+    });
+  });
+
+  it('should not append empty violations', () => {
+    const validate = createValidator({
+      constraints: {
+        passedConstraint,
+      },
+    });
+
+    const rules = {
+      name: {
+        passedConstraint: {},
+      },
+    };
+
+    const violations = validate({ name: 'John' }, rules);
+
+    expect(violations).toHaveLength(0);
+  });
+
+  it('should validate field with multiple constraints', () => {
+    const validate = createValidator({
+      constraints: {
+        customConstraint,
+        anotherCustomConstraint,
+      },
+    });
+
+    const rules = {
+      name: {
+        customConstraint: {},
+        anotherCustomConstraint: {},
+      },
+    };
+
+    const violations = validate({ name: '' }, rules);
+
+    expect(violations).toHaveLength(2);
+    expect(violations[0]).toEqual({
+      path: 'name',
+      constraint: 'customConstraint',
+      message: 'Custom constraint validation failed',
+      value: '',
+    });
+    expect(violations[1]).toEqual({
+      path: 'name',
+      constraint: 'anotherCustomConstraint',
+      message: 'Another custom constraint validation failed',
+      value: '',
+    });
+  });
+});
+
+function customConstraint(value: unknown, context: ConstraintContext): Violation[] {
+  return [
+    {
+      path: context.path,
+      message: 'Custom constraint validation failed',
+      constraint: context.constraint,
+      value,
+    },
+  ];
+}
+
+function anotherCustomConstraint(value: unknown, context: ConstraintContext): Violation[] {
+  return [
+    {
+      path: context.path,
+      message: 'Another custom constraint validation failed',
+      constraint: context.constraint,
+      value,
+    },
+  ];
+}
+
+function passedConstraint(_: unknown, __: ConstraintContext): Violation[] {
+  return [];
+}

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { UnknownConstraintError } from './errors';
 import type { ConstraintContext, Violation } from './types';
 import { createValidator } from './validator';
 
@@ -12,9 +13,7 @@ describe('Validator', () => {
       },
     };
 
-    expect(() => validate({ name: 'John' }, rules)).toThrowError(
-      'Field "name" references unregistered constraint "required"',
-    );
+    expect(() => validate({ name: 'John' }, rules)).toThrowError(UnknownConstraintError);
   });
 
   it('should use provided constraints registry to validate rules', () => {

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -4,121 +4,154 @@ import type { ConstraintContext, Violation } from './types';
 import { createValidator } from './validator';
 
 describe('Validator', () => {
-  it('should fail when a rule references an undefined constraint', () => {
-    const validate = createValidator({ constraints: {} });
+  describe('Registry', () => {
+    it('should fail when a rule references an undefined constraint', () => {
+      const validate = createValidator({ constraints: {} });
 
-    const rules = {
-      name: {
-        required: {},
-      },
-    };
+      const rules = {
+        name: {
+          required: {},
+        },
+      };
 
-    expect(() => validate({ name: 'John' }, rules)).toThrowError(UnknownConstraintError);
-  });
-
-  it('should use provided constraints registry to validate rules', () => {
-    const validate = createValidator({
-      constraints: {
-        customConstraint,
-      },
-    });
-
-    const rules = {
-      name: {
-        customConstraint: {},
-      },
-    };
-
-    const violations = validate({ name: '' }, rules);
-
-    expect(violations).toHaveLength(1);
-    expect(violations[0]).toEqual({
-      path: 'name',
-      constraint: 'customConstraint',
-      message: 'Custom constraint validation failed',
-      value: '',
+      expect(() => validate({ name: 'John' }, rules)).toThrowError(UnknownConstraintError);
+      expect(() => validate({ name: 'John' }, rules)).toThrowError(
+        'Field "name" references unregistered constraint "required"',
+      );
     });
   });
 
-  it('should map each violation to the invalid field', () => {
-    const validate = createValidator({
-      constraints: {
-        customConstraint,
-      },
-    });
-    const rules = {
-      name: {
-        customConstraint: {},
-      },
-      age: {
-        customConstraint: {},
-      },
-    };
+  describe('Violations', () => {
+    it('should use provided constraints registry to validate rules', () => {
+      const validate = createValidator({
+        constraints: {
+          customConstraint,
+        },
+      });
 
-    const violations = validate({ name: '', age: 30 }, rules);
+      const rules = {
+        name: {
+          customConstraint: {},
+        },
+      };
 
-    expect(violations).toHaveLength(2);
-    expect(violations[0]).toEqual({
-      path: 'name',
-      constraint: 'customConstraint',
-      message: 'Custom constraint validation failed',
-      value: '',
+      const violations = validate({ name: '' }, rules);
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0]).toEqual({
+        path: 'name',
+        constraint: 'customConstraint',
+        message: 'Custom constraint validation failed',
+        value: '',
+      });
     });
-    expect(violations[1]).toEqual({
-      path: 'age',
-      constraint: 'customConstraint',
-      message: 'Custom constraint validation failed',
-      value: 30,
+
+    it('should map each violation to the invalid field', () => {
+      const validate = createValidator({
+        constraints: {
+          customConstraint,
+        },
+      });
+      const rules = {
+        name: {
+          customConstraint: {},
+        },
+        age: {
+          customConstraint: {},
+        },
+      };
+
+      const violations = validate({ name: '', age: 30 }, rules);
+
+      expect(violations).toHaveLength(2);
+      expect(violations[0]).toEqual({
+        path: 'name',
+        constraint: 'customConstraint',
+        message: 'Custom constraint validation failed',
+        value: '',
+      });
+      expect(violations[1]).toEqual({
+        path: 'age',
+        constraint: 'customConstraint',
+        message: 'Custom constraint validation failed',
+        value: 30,
+      });
+    });
+
+    it('should not append empty violations', () => {
+      const validate = createValidator({
+        constraints: {
+          passedConstraint,
+        },
+      });
+
+      const rules = {
+        name: {
+          passedConstraint: {},
+        },
+      };
+
+      const violations = validate({ name: 'John' }, rules);
+
+      expect(violations).toHaveLength(0);
+    });
+
+    it('should validate field with multiple constraints', () => {
+      const validate = createValidator({
+        constraints: {
+          customConstraint,
+          anotherCustomConstraint,
+        },
+      });
+
+      const rules = {
+        name: {
+          customConstraint: {},
+          anotherCustomConstraint: {},
+        },
+      };
+
+      const violations = validate({ name: '' }, rules);
+
+      expect(violations).toHaveLength(2);
+      expect(violations[0]).toEqual({
+        path: 'name',
+        constraint: 'customConstraint',
+        message: 'Custom constraint validation failed',
+        value: '',
+      });
+      expect(violations[1]).toEqual({
+        path: 'name',
+        constraint: 'anotherCustomConstraint',
+        message: 'Another custom constraint validation failed',
+        value: '',
+      });
     });
   });
 
-  it('should not append empty violations', () => {
-    const validate = createValidator({
-      constraints: {
-        passedConstraint,
-      },
-    });
+  describe('Constraint options', () => {
+    it('should pass rule options to constraints', () => {
+      const validate = createValidator({
+        constraints: {
+          minLengthConstraint,
+        },
+      });
 
-    const rules = {
-      name: {
-        passedConstraint: {},
-      },
-    };
+      const rules = {
+        name: {
+          minLengthConstraint: { min: 3 },
+        },
+      };
 
-    const violations = validate({ name: 'John' }, rules);
+      const violations = validate({ name: 'ab' }, rules);
 
-    expect(violations).toHaveLength(0);
-  });
-
-  it('should validate field with multiple constraints', () => {
-    const validate = createValidator({
-      constraints: {
-        customConstraint,
-        anotherCustomConstraint,
-      },
-    });
-
-    const rules = {
-      name: {
-        customConstraint: {},
-        anotherCustomConstraint: {},
-      },
-    };
-
-    const violations = validate({ name: '' }, rules);
-
-    expect(violations).toHaveLength(2);
-    expect(violations[0]).toEqual({
-      path: 'name',
-      constraint: 'customConstraint',
-      message: 'Custom constraint validation failed',
-      value: '',
-    });
-    expect(violations[1]).toEqual({
-      path: 'name',
-      constraint: 'anotherCustomConstraint',
-      message: 'Another custom constraint validation failed',
-      value: '',
+      expect(violations).toHaveLength(1);
+      expect(violations[0]).toEqual({
+        path: 'name',
+        constraint: 'minLengthConstraint',
+        message: 'Must be at least 3 characters',
+        value: 'ab',
+      });
     });
   });
 });
@@ -146,5 +179,22 @@ function anotherCustomConstraint(value: unknown, context: ConstraintContext): Vi
 }
 
 function passedConstraint(_: unknown, __: ConstraintContext): Violation[] {
+  return [];
+}
+
+function minLengthConstraint(value: unknown, context: ConstraintContext): Violation[] {
+  const min = context.options.min;
+
+  if (typeof value === 'string' && typeof min === 'number' && value.length < min) {
+    return [
+      {
+        path: context.path,
+        message: `Must be at least ${min} characters`,
+        constraint: context.constraint,
+        value,
+      },
+    ];
+  }
+
   return [];
 }

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -253,6 +253,28 @@ describe('Validator', () => {
         value: '',
       });
     });
+
+    it('should fall back to the Default group when groups are empty', () => {
+      const validate = createValidator({
+        constraints: {
+          groupedConstraint,
+        },
+      });
+
+      const rules = {
+        email: [{ groupedConstraint: { groups: ['Default'] } }],
+      };
+
+      const violations = validate({ email: '' }, rules, { groups: [] });
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0]).toEqual({
+        path: 'email',
+        constraint: 'groupedConstraint',
+        message: 'Grouped constraint failed',
+        value: '',
+      });
+    });
   });
 });
 

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -14,7 +14,7 @@ describe('Validator', () => {
 
       expect(() => validate({ name: 'John' }, rules)).toThrowError(UnknownConstraintError);
       expect(() => validate({ name: 'John' }, rules)).toThrowError(
-        'Field "name" references unregistered constraint "required"',
+        'Field "name" references unregistered constraint "required".',
       );
     });
   });

--- a/src/validator/validator.test.ts
+++ b/src/validator/validator.test.ts
@@ -154,6 +154,26 @@ describe('Validator', () => {
       });
     });
   });
+
+  describe('Groups', () => {
+    it('should skip constraints when groups do not intersect', () => {
+      const validate = createValidator({
+        constraints: {
+          groupedConstraint,
+        },
+      });
+
+      const rules = {
+        email: {
+          groupedConstraint: { groups: ['create'] },
+        },
+      };
+
+      const violations = validate({ email: '' }, rules, { groups: ['update'] });
+
+      expect(violations).toHaveLength(0);
+    });
+  });
 });
 
 function customConstraint(value: unknown, context: ConstraintContext): Violation[] {
@@ -190,6 +210,21 @@ function minLengthConstraint(value: unknown, context: ConstraintContext): Violat
       {
         path: context.path,
         message: `Must be at least ${min} characters`,
+        constraint: context.constraint,
+        value,
+      },
+    ];
+  }
+
+  return [];
+}
+
+function groupedConstraint(value: unknown, context: ConstraintContext): Violation[] {
+  if (value === '' || value === null || value === undefined) {
+    return [
+      {
+        path: context.path,
+        message: 'Grouped constraint failed',
         constraint: context.constraint,
         value,
       },

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -4,6 +4,7 @@ import {
   ConstraintOptions,
   ConstraintsMap,
   ConstraintValidator,
+  FieldRuleEntry,
   FieldRules,
   Payload,
   ValidateOptions,
@@ -65,16 +66,32 @@ function applyFieldRules(
   activeGroups: string[],
 ): ReturnType<ConstraintValidator> {
   const value = payload[field];
+  const normalizedRules = normalizeFieldRules(fieldRules);
 
-  return Object.keys(fieldRules).flatMap(constraintName => {
+  return normalizedRules.flatMap(([constraintName, options]) => {
     const constraintValidator = resolveConstraint(constraintValidatorMap, field, constraintName);
-    const options = fieldRules[constraintName];
     const constraintGroups = options?.groups ?? [];
 
     if (constraintGroups.length > 0 && !constraintGroups.some(group => activeGroups.includes(group))) {
       return [];
     }
 
-    return applyConstraint(constraintValidator, payload, field, constraintName, value, options as ConstraintOptions);
+    return applyConstraint(constraintValidator, payload, field, constraintName, value, options);
   });
+}
+
+function normalizeFieldRules(fieldRules: FieldRules): Array<[string, ConstraintOptions]> {
+  if (Array.isArray(fieldRules)) {
+    return fieldRules.flatMap(entry => normalizeFieldRuleEntry(entry));
+  }
+
+  return Object.entries(fieldRules).map(([constraintName, options]) => [constraintName, options ?? {}]);
+}
+
+function normalizeFieldRuleEntry(entry: FieldRuleEntry): Array<[string, ConstraintOptions]> {
+  if (typeof entry === 'string') {
+    return [[entry, {}]];
+  }
+
+  return Object.entries(entry).map(([constraintName, options]) => [constraintName, options ?? {}]);
 }

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -1,0 +1,28 @@
+import type { ConstraintContext, CreateValidatorOptions, Payload, ValidationRules, Validator } from './types';
+
+export const createValidator = (options: CreateValidatorOptions): Validator => {
+  const { constraints } = options;
+
+  return function validate(payload: Payload, rules: ValidationRules) {
+    return Object.entries(rules).flatMap(([field, fieldRules]) => {
+      const value = payload[field];
+
+      return Object.keys(fieldRules).flatMap(constraintName => {
+        const constraintValidator = constraints[constraintName];
+
+        if (!constraintValidator) {
+          throw new Error(`Field "${field}" references unregistered constraint "${constraintName}".`);
+        }
+
+        const context: ConstraintContext = {
+          path: field,
+          root: payload,
+          value,
+          constraint: constraintName,
+        };
+
+        return constraintValidator(value, context);
+      });
+    });
+  };
+};

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -60,7 +60,7 @@ function applyFieldRules(
       value,
       constraint: constraintName,
       options,
-      applyConstraints: applyNestedRules,
+      runNestedRules: applyNestedRules,
     };
 
     return constraintValidator(value, context);

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -13,17 +13,56 @@ import {
   ValidatorOptions,
 } from './types';
 
+type FieldEntry = [string, FieldRules];
+
 export const createValidator = (options: ValidatorOptions): Validator => {
   const { constraints } = options;
 
   return function validate(payload: Payload, rules: ValidationRules, options?: ValidateOptions) {
-    const entries = Object.entries(rules);
+    const ruleEntries: FieldEntry[] = Object.entries(rules);
+
     // If no groups are provided, implicitly validate against "Default".
     const activeGroups = options?.groups && options.groups.length > 0 ? options.groups : ['Default'];
 
-    return entries.flatMap(fieldEntry => applyFieldRules(constraints, payload, fieldEntry as FieldEntry, activeGroups));
+    // Apply all field rules and aggregate results.
+    return ruleEntries.flatMap(function (fieldEntry: FieldEntry) {
+      return applyFieldRules(constraints, payload, fieldEntry, activeGroups);
+    });
   };
 };
+
+function applyFieldRules(
+  constraintsByName: ConstraintsMap,
+  payload: Payload,
+  [field, rulesForField]: FieldEntry,
+  activeGroups: string[],
+  currentValue?: unknown,
+): ReturnType<ConstraintValidator> {
+  const isGroupActive = (groups: string[]) => groups.length === 0 || groups.some(group => activeGroups.includes(group));
+
+  const normalizedFieldRules = normalizeFieldRules(rulesForField);
+
+  return normalizedFieldRules.flatMap(([constraintName, options]) => {
+    const groups = options?.groups ?? [];
+    if (!isGroupActive(groups)) return [];
+
+    const applyNestedRules = (nextValue: unknown, rules: FieldRules, path: string) =>
+      applyFieldRules(constraintsByName, payload, [path, rules], activeGroups, nextValue);
+
+    const constraintValidator = resolveConstraint(constraintsByName, field, constraintName);
+    const value = currentValue ?? payload[field];
+    const context: ConstraintContext = {
+      path: field,
+      root: payload,
+      value,
+      constraint: constraintName,
+      options,
+      applyConstraints: applyNestedRules,
+    };
+
+    return constraintValidator(value, context);
+  });
+}
 
 function resolveConstraint(
   constraintValidatorMap: ConstraintsMap,
@@ -37,55 +76,6 @@ function resolveConstraint(
   }
 
   return constraintValidator;
-}
-
-function applyConstraint(
-  constraintValidator: ConstraintValidator,
-  payload: Payload,
-  field: string,
-  constraintName: string,
-  value: unknown,
-  options: ConstraintOptions,
-  applyConstraints: ConstraintContext['applyConstraints'],
-): ReturnType<ConstraintValidator> {
-  const context: ConstraintContext = {
-    path: field,
-    root: payload,
-    value,
-    constraint: constraintName,
-    options,
-    applyConstraints,
-  };
-
-  return constraintValidator(value, context);
-}
-
-type FieldEntry = [string, FieldRules];
-
-function applyFieldRules(
-  constraintValidatorMap: ConstraintsMap,
-  payload: Payload,
-  [field, fieldRules]: FieldEntry,
-  activeGroups: string[],
-  currentValue?: unknown,
-): ReturnType<ConstraintValidator> {
-  const value = currentValue ?? payload[field];
-  const normalizedRules = normalizeFieldRules(fieldRules);
-  // Reuse the same validation pipeline for nested/compound rules.
-  const applyConstraints = (nextValue: unknown, rules: FieldRules, path: string) =>
-    applyFieldRules(constraintValidatorMap, payload, [path, rules], activeGroups, nextValue);
-
-  return normalizedRules.flatMap(([constraintName, options]) => {
-    const constraintValidator = resolveConstraint(constraintValidatorMap, field, constraintName);
-    const constraintGroups = options?.groups ?? [];
-
-    // Skip constraints whose groups are not active for this validation run.
-    if (constraintGroups.length > 0 && !constraintGroups.some(group => activeGroups.includes(group))) {
-      return [];
-    }
-
-    return applyConstraint(constraintValidator, payload, field, constraintName, value, options, applyConstraints);
-  });
 }
 
 function normalizeFieldRules(fieldRules: FieldRules): Array<[string, ConstraintOptions]> {

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -17,7 +17,7 @@ export const createValidator = (options: ValidatorOptions): Validator => {
 
   return function validate(payload: Payload, rules: ValidationRules, options?: ValidateOptions) {
     const entries = Object.entries(rules);
-    const activeGroups = options?.groups ?? [];
+    const activeGroups = options?.groups && options.groups.length > 0 ? options.groups : ['Default'];
 
     return entries.flatMap(fieldEntry => applyFieldRules(constraints, payload, fieldEntry as FieldEntry, activeGroups));
   };
@@ -69,7 +69,7 @@ function applyFieldRules(
   return Object.keys(fieldRules).flatMap(constraintName => {
     const constraintValidator = resolveConstraint(constraintValidatorMap, field, constraintName);
     const options = fieldRules[constraintName];
-    const constraintGroups = options.groups ?? [];
+    const constraintGroups = options?.groups ?? [];
 
     if (constraintGroups.length > 0 && !constraintGroups.some(group => activeGroups.includes(group))) {
       return [];

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -18,6 +18,7 @@ export const createValidator = (options: ValidatorOptions): Validator => {
 
   return function validate(payload: Payload, rules: ValidationRules, options?: ValidateOptions) {
     const entries = Object.entries(rules);
+    // If no groups are provided, implicitly validate against "Default".
     const activeGroups = options?.groups && options.groups.length > 0 ? options.groups : ['Default'];
 
     return entries.flatMap(fieldEntry => applyFieldRules(constraints, payload, fieldEntry as FieldEntry, activeGroups));
@@ -70,6 +71,7 @@ function applyFieldRules(
 ): ReturnType<ConstraintValidator> {
   const value = currentValue ?? payload[field];
   const normalizedRules = normalizeFieldRules(fieldRules);
+  // Reuse the same validation pipeline for nested/compound rules.
   const applyConstraints = (nextValue: unknown, rules: FieldRules, path: string) =>
     applyFieldRules(constraintValidatorMap, payload, [path, rules], activeGroups, nextValue);
 
@@ -77,6 +79,7 @@ function applyFieldRules(
     const constraintValidator = resolveConstraint(constraintValidatorMap, field, constraintName);
     const constraintGroups = options?.groups ?? [];
 
+    // Skip constraints whose groups are not active for this validation run.
     if (constraintGroups.length > 0 && !constraintGroups.some(group => activeGroups.includes(group))) {
       return [];
     }
@@ -86,6 +89,7 @@ function applyFieldRules(
 }
 
 function normalizeFieldRules(fieldRules: FieldRules): Array<[string, ConstraintOptions]> {
+  // Normalize rule shapes (array or map) into a consistent tuple list.
   if (Array.isArray(fieldRules)) {
     return fieldRules.flatMap(entry => normalizeFieldRuleEntry(entry));
   }
@@ -94,6 +98,7 @@ function normalizeFieldRules(fieldRules: FieldRules): Array<[string, ConstraintO
 }
 
 function normalizeFieldRuleEntry(entry: FieldRuleEntry): Array<[string, ConstraintOptions]> {
+  // Convert shorthand rule declarations into a full [name, options] tuple.
   if (typeof entry === 'string') {
     return [[entry, {}]];
   }

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -6,6 +6,7 @@ import {
   ConstraintValidator,
   FieldRules,
   Payload,
+  ValidateOptions,
   ValidationRules,
   Validator,
   ValidatorOptions,
@@ -14,10 +15,11 @@ import {
 export const createValidator = (options: ValidatorOptions): Validator => {
   const { constraints } = options;
 
-  return function validate(payload: Payload, rules: ValidationRules) {
+  return function validate(payload: Payload, rules: ValidationRules, options?: ValidateOptions) {
     const entries = Object.entries(rules);
+    const activeGroups = options?.groups ?? [];
 
-    return entries.flatMap(fieldEntry => applyFieldRules(constraints, payload, fieldEntry as FieldEntry));
+    return entries.flatMap(fieldEntry => applyFieldRules(constraints, payload, fieldEntry as FieldEntry, activeGroups));
   };
 };
 
@@ -60,12 +62,19 @@ function applyFieldRules(
   constraintValidatorMap: ConstraintsMap,
   payload: Payload,
   [field, fieldRules]: FieldEntry,
+  activeGroups: string[],
 ): ReturnType<ConstraintValidator> {
   const value = payload[field];
 
   return Object.keys(fieldRules).flatMap(constraintName => {
     const constraintValidator = resolveConstraint(constraintValidatorMap, field, constraintName);
     const options = fieldRules[constraintName];
+    const constraintGroups = options.groups ?? [];
+
+    if (constraintGroups.length > 0 && !constraintGroups.some(group => activeGroups.includes(group))) {
+      return [];
+    }
+
     return applyConstraint(constraintValidator, payload, field, constraintName, value, options as ConstraintOptions);
   });
 }

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -1,28 +1,63 @@
-import type { ConstraintContext, CreateValidatorOptions, Payload, ValidationRules, Validator } from './types';
+import type {
+  ConstraintContext,
+  ConstraintValidator,
+  FieldRules,
+  Payload,
+  ValidationRules,
+  Validator,
+  ValidatorOptions,
+} from './types';
 
-export const createValidator = (options: CreateValidatorOptions): Validator => {
+export const createValidator = (options: ValidatorOptions): Validator => {
   const { constraints } = options;
 
   return function validate(payload: Payload, rules: ValidationRules) {
-    return Object.entries(rules).flatMap(([field, fieldRules]) => {
-      const value = payload[field];
-
-      return Object.keys(fieldRules).flatMap(constraintName => {
-        const constraintValidator = constraints[constraintName];
-
-        if (!constraintValidator) {
-          throw new Error(`Field "${field}" references unregistered constraint "${constraintName}".`);
-        }
-
-        const context: ConstraintContext = {
-          path: field,
-          root: payload,
-          value,
-          constraint: constraintName,
-        };
-
-        return constraintValidator(value, context);
-      });
-    });
+    return Object.entries(rules).flatMap(fieldEntry => applyFieldRules(constraints, payload, fieldEntry as FieldEntry));
   };
 };
+
+function resolveConstraint(
+  constraints: ValidatorOptions['constraints'],
+  field: string,
+  constraintName: string,
+): ConstraintValidator {
+  const constraintValidator = constraints[constraintName];
+
+  if (!constraintValidator) {
+    throw new Error(`Field "${field}" references unregistered constraint "${constraintName}".`);
+  }
+
+  return constraintValidator;
+}
+
+function applyConstraint(
+  constraintValidator: ConstraintValidator,
+  payload: Payload,
+  field: string,
+  constraintName: string,
+  value: unknown,
+): ReturnType<ConstraintValidator> {
+  const context: ConstraintContext = {
+    path: field,
+    root: payload,
+    value,
+    constraint: constraintName,
+  };
+
+  return constraintValidator(value, context);
+}
+
+type FieldEntry = [string, FieldRules];
+
+function applyFieldRules(
+  constraints: ValidatorOptions['constraints'],
+  payload: Payload,
+  [field, fieldRules]: FieldEntry,
+): ReturnType<ConstraintValidator> {
+  const value = payload[field];
+
+  return Object.keys(fieldRules).flatMap(constraintName => {
+    const constraintValidator = resolveConstraint(constraints, field, constraintName);
+    return applyConstraint(constraintValidator, payload, field, constraintName, value);
+  });
+}

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -1,5 +1,8 @@
-import type {
+import { UnknownConstraintError } from './errors';
+import {
   ConstraintContext,
+  ConstraintOptions,
+  ConstraintsMap,
   ConstraintValidator,
   FieldRules,
   Payload,
@@ -7,7 +10,6 @@ import type {
   Validator,
   ValidatorOptions,
 } from './types';
-import { UnknownConstraintError } from './errors';
 
 export const createValidator = (options: ValidatorOptions): Validator => {
   const { constraints } = options;
@@ -20,11 +22,11 @@ export const createValidator = (options: ValidatorOptions): Validator => {
 };
 
 function resolveConstraint(
-  constraints: ValidatorOptions['constraints'],
+  constraintValidatorMap: ConstraintsMap,
   field: string,
   constraintName: string,
 ): ConstraintValidator {
-  const constraintValidator = constraints[constraintName];
+  const constraintValidator = constraintValidatorMap[constraintName];
 
   if (!constraintValidator) {
     throw new UnknownConstraintError(field, constraintName);
@@ -39,12 +41,14 @@ function applyConstraint(
   field: string,
   constraintName: string,
   value: unknown,
+  options: ConstraintOptions,
 ): ReturnType<ConstraintValidator> {
   const context: ConstraintContext = {
     path: field,
     root: payload,
     value,
     constraint: constraintName,
+    options,
   };
 
   return constraintValidator(value, context);
@@ -53,14 +57,15 @@ function applyConstraint(
 type FieldEntry = [string, FieldRules];
 
 function applyFieldRules(
-  constraints: ValidatorOptions['constraints'],
+  constraintValidatorMap: ConstraintsMap,
   payload: Payload,
   [field, fieldRules]: FieldEntry,
 ): ReturnType<ConstraintValidator> {
   const value = payload[field];
 
   return Object.keys(fieldRules).flatMap(constraintName => {
-    const constraintValidator = resolveConstraint(constraints, field, constraintName);
-    return applyConstraint(constraintValidator, payload, field, constraintName, value);
+    const constraintValidator = resolveConstraint(constraintValidatorMap, field, constraintName);
+    const options = fieldRules[constraintName];
+    return applyConstraint(constraintValidator, payload, field, constraintName, value, options as ConstraintOptions);
   });
 }

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -85,7 +85,7 @@ function normalizeFieldRules(fieldRules: FieldRules): Array<[string, ConstraintO
     return fieldRules.flatMap(entry => normalizeFieldRuleEntry(entry));
   }
 
-  return Object.entries(fieldRules).map(([constraintName, options]) => [constraintName, options ?? {}]);
+  return Object.entries(fieldRules).map(([constraintName, options]) => [constraintName, options]);
 }
 
 function normalizeFieldRuleEntry(entry: FieldRuleEntry): Array<[string, ConstraintOptions]> {
@@ -93,5 +93,5 @@ function normalizeFieldRuleEntry(entry: FieldRuleEntry): Array<[string, Constrai
     return [[entry, {}]];
   }
 
-  return Object.entries(entry).map(([constraintName, options]) => [constraintName, options ?? {}]);
+  return Object.entries(entry).map(([constraintName, options]) => [constraintName, options]);
 }

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -43,12 +43,15 @@ function applyFieldRules(
   const normalizedFieldRules = normalizeFieldRules(rulesForField);
 
   return normalizedFieldRules.flatMap(([constraintName, options]) => {
+    // Check if the constraint should be applied based on groups.
     const groups = options?.groups ?? [];
     if (!isGroupActive(groups)) return [];
 
+    // Helper function to apply nested rules.
     const applyNestedRules = (nextValue: unknown, rules: FieldRules, path: string) =>
       applyFieldRules(constraintsByName, payload, [path, rules], activeGroups, nextValue);
 
+    // Find the constraint, build the context, and apply it.
     const constraintValidator = resolveConstraint(constraintsByName, field, constraintName);
     const value = currentValue ?? payload[field];
     const context: ConstraintContext = {

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -45,6 +45,7 @@ function applyConstraint(
   constraintName: string,
   value: unknown,
   options: ConstraintOptions,
+  applyConstraints: ConstraintContext['applyConstraints'],
 ): ReturnType<ConstraintValidator> {
   const context: ConstraintContext = {
     path: field,
@@ -52,6 +53,7 @@ function applyConstraint(
     value,
     constraint: constraintName,
     options,
+    applyConstraints,
   };
 
   return constraintValidator(value, context);
@@ -67,6 +69,8 @@ function applyFieldRules(
 ): ReturnType<ConstraintValidator> {
   const value = payload[field];
   const normalizedRules = normalizeFieldRules(fieldRules);
+  const applyConstraints = (nextValue: unknown, rules: FieldRules, path: string) =>
+    applyFieldRules(constraintValidatorMap, payload, [path, rules], activeGroups);
 
   return normalizedRules.flatMap(([constraintName, options]) => {
     const constraintValidator = resolveConstraint(constraintValidatorMap, field, constraintName);
@@ -76,7 +80,7 @@ function applyFieldRules(
       return [];
     }
 
-    return applyConstraint(constraintValidator, payload, field, constraintName, value, options);
+    return applyConstraint(constraintValidator, payload, field, constraintName, value, options, applyConstraints);
   });
 }
 

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -7,6 +7,7 @@ import type {
   Validator,
   ValidatorOptions,
 } from './types';
+import { UnknownConstraintError } from './errors';
 
 export const createValidator = (options: ValidatorOptions): Validator => {
   const { constraints } = options;
@@ -26,7 +27,7 @@ function resolveConstraint(
   const constraintValidator = constraints[constraintName];
 
   if (!constraintValidator) {
-    throw new Error(`Field "${field}" references unregistered constraint "${constraintName}".`);
+    throw new UnknownConstraintError(field, constraintName);
   }
 
   return constraintValidator;

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -66,11 +66,12 @@ function applyFieldRules(
   payload: Payload,
   [field, fieldRules]: FieldEntry,
   activeGroups: string[],
+  currentValue?: unknown,
 ): ReturnType<ConstraintValidator> {
-  const value = payload[field];
+  const value = currentValue ?? payload[field];
   const normalizedRules = normalizeFieldRules(fieldRules);
   const applyConstraints = (nextValue: unknown, rules: FieldRules, path: string) =>
-    applyFieldRules(constraintValidatorMap, payload, [path, rules], activeGroups);
+    applyFieldRules(constraintValidatorMap, payload, [path, rules], activeGroups, nextValue);
 
   return normalizedRules.flatMap(([constraintName, options]) => {
     const constraintValidator = resolveConstraint(constraintValidatorMap, field, constraintName);

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -12,7 +12,9 @@ export const createValidator = (options: ValidatorOptions): Validator => {
   const { constraints } = options;
 
   return function validate(payload: Payload, rules: ValidationRules) {
-    return Object.entries(rules).flatMap(fieldEntry => applyFieldRules(constraints, payload, fieldEntry as FieldEntry));
+    const entries = Object.entries(rules);
+
+    return entries.flatMap(fieldEntry => applyFieldRules(constraints, payload, fieldEntry as FieldEntry));
   };
 };
 


### PR DESCRIPTION
| Q       | A                      |
| ------- | ---------------------- |
| License | GPLv3                  |
| Issue   | Closes #102 |

**Summary**
Introduce a new validation component that enables declarative, constraint‑based validation for payloads. The validator supports reusable constraints, rule normalization, groups, and compound constraints for composing validations.

**What’s Included**
- `createValidator` factory that applies field rules to payloads and returns violations.
- Constraint registry for plugging in custom validators.
- Rule normalization to support array, object, and mixed rule declarations.
- Group‑based validation with a `Default` fallback.
- Constraint context with metadata and `applyConstraints` for nested/compound validation.
- Built‑in constraints and comprehensive unit/integration tests.

**Key Concepts**
- **Rules**: Map field names to constraint rules (arrays or objects).
- **Violations**: Standardized error objects with `path`, `constraint`, `message`, `value`.
- **Groups**: Activate subsets of constraints per validation run.
- **Compound constraints**: Compose multiple constraints as a single reusable rule.

**Usage Example**
```ts
import { createValidator } from '@koala-ts/framework/validator';
import { notBlank } from '@koala-ts/framework/validator/constraints/basic/not-blank';
import { email } from '@koala-ts/framework/validator/constraints/string/email';
import { compound } from '@koala-ts/framework/validator/constraints/other/compound';

const requiredEmail = compound([
  'notBlank',
  { email: { message: 'Invalid email' } },
]);

const validate = createValidator({
  constraints: { notBlank, email, requiredEmail },
});

const rules = { userEmail: ['requiredEmail'] };

const violations = validate({ userEmail: '' }, rules);
// => [ { path: 'userEmail', constraint: 'notBlank', ... }, { path: 'userEmail', constraint: 'email', ... } ]
```