### PR TITLE
feat(routing): add http verb route helpers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1614,7 +1614,6 @@
       "integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.1",
         "@typescript-eslint/types": "8.57.1",
@@ -1963,7 +1962,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2841,7 +2839,6 @@
       "integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -2898,7 +2895,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -3673,7 +3669,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -3733,7 +3728,6 @@
       "resolved": "https://registry.npmjs.org/koa/-/koa-3.1.2.tgz",
       "integrity": "sha512-2LOQnFKu3m0VxpE+5sb5+BRTSKrXmNxGgxVRiKwD9s5KQB1zID/FRXhtzeV7RT1L2GVpdEEAfVuclFOMGl1ikA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^1.3.8",
         "content-disposition": "~1.0.1",
@@ -4149,7 +4143,6 @@
       "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -4675,7 +4668,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -5328,7 +5320,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5436,7 +5427,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -5524,7 +5514,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5617,7 +5606,6 @@
       "integrity": "sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.3",
@@ -5709,7 +5697,6 @@
       "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.0",
         "@vitest/mocker": "4.1.0",

--- a/src/routing/http-verb-helpers.test.ts
+++ b/src/routing/http-verb-helpers.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test, vi } from 'vitest';
+import { Any, Delete, Get, Head, Options, Patch, Post, Put } from './http-verb-helpers';
+
+describe('routing http verb helpers', () => {
+  test.each([
+    ['Get', Get, ['get']],
+    ['Post', Post, ['post']],
+    ['Put', Put, ['put']],
+    ['Patch', Patch, ['patch']],
+    ['Delete', Delete, ['delete']],
+    ['Head', Head, ['head']],
+    ['Options', Options, ['options']],
+    ['Any', Any, ['all']],
+  ])('it creates a %s route through the canonical route contract', (_name, helper, methods) => {
+    const handler = vi.fn(async () => undefined);
+
+    const route = helper('/users', handler);
+
+    expect(route).toEqual({
+      bodyOptions: {},
+      handler,
+      methods,
+      middleware: [],
+      parseBody: true,
+      path: '/users',
+    });
+  });
+});

--- a/src/routing/http-verb-helpers.test.ts
+++ b/src/routing/http-verb-helpers.test.ts
@@ -25,4 +25,35 @@ describe('routing http verb helpers', () => {
       path: '/users',
     });
   });
+
+  test.each([
+    ['Get', Get, ['get']],
+    ['Post', Post, ['post']],
+    ['Put', Put, ['put']],
+    ['Patch', Patch, ['patch']],
+    ['Delete', Delete, ['delete']],
+    ['Head', Head, ['head']],
+    ['Options', Options, ['options']],
+    ['Any', Any, ['all']],
+  ])('it creates a named %s route through the canonical route contract', (_name, helper, methods) => {
+    const handler = vi.fn(async () => undefined);
+
+    const route = helper('/users', 'users.list', handler);
+
+    expect(route).toEqual({
+      bodyOptions: {},
+      handler,
+      methods,
+      middleware: [],
+      name: 'users.list',
+      parseBody: true,
+      path: '/users',
+    });
+  });
+
+  test('it rejects a named helper call without a handler', () => {
+    const get = Get as unknown as (path: string, name: string) => unknown;
+
+    expect(() => get('/users', 'users.list')).toThrow('Named verb helpers require a handler.');
+  });
 });

--- a/src/routing/http-verb-helpers.ts
+++ b/src/routing/http-verb-helpers.ts
@@ -1,0 +1,24 @@
+import type { HttpMiddleware } from '@/Http';
+import type { HttpMethod } from '@/routing/http-method';
+import { Route } from './route';
+import type { RouteDefinition } from './route-definition';
+
+type RouteHandler = HttpMiddleware;
+
+function createVerbHelper(method: HttpMethod): (path: string, handler: RouteHandler) => RouteDefinition {
+  return (path, handler) =>
+    Route({
+      method,
+      path,
+      handler,
+    });
+}
+
+export const Get = createVerbHelper('GET');
+export const Post = createVerbHelper('POST');
+export const Put = createVerbHelper('PUT');
+export const Patch = createVerbHelper('PATCH');
+export const Delete = createVerbHelper('DELETE');
+export const Head = createVerbHelper('HEAD');
+export const Options = createVerbHelper('OPTIONS');
+export const Any = createVerbHelper('ANY');

--- a/src/routing/http-verb-helpers.ts
+++ b/src/routing/http-verb-helpers.ts
@@ -4,14 +4,47 @@ import { Route } from './route';
 import type { RouteDefinition } from './route-definition';
 
 type RouteHandler = HttpMiddleware;
+interface VerbHelperArguments {
+  path: string;
+  name?: string;
+  handler: RouteHandler;
+}
 
-function createVerbHelper(method: HttpMethod): (path: string, handler: RouteHandler) => RouteDefinition {
-  return (path, handler) =>
+type NamedVerbHelper = {
+  (path: string, handler: RouteHandler): RouteDefinition;
+  (path: string, name: string, handler: RouteHandler): RouteDefinition;
+};
+
+function createVerbHelper(method: HttpMethod): NamedVerbHelper {
+  return (path: string, nameOrHandler: string | RouteHandler, maybeHandler?: RouteHandler) =>
     Route({
       method,
-      path,
-      handler,
+      ...resolveVerbHelperArguments(path, nameOrHandler, maybeHandler),
     });
+}
+
+function resolveVerbHelperArguments(
+  path: string,
+  nameOrHandler: string | RouteHandler,
+  maybeHandler?: RouteHandler,
+): VerbHelperArguments {
+  const isNamedRoute = typeof nameOrHandler === 'string';
+  const name = isNamedRoute ? nameOrHandler : undefined;
+  const handler = isNamedRoute ? requireNamedVerbHelperHandler(maybeHandler) : nameOrHandler;
+
+  return {
+    path,
+    name,
+    handler,
+  };
+}
+
+function requireNamedVerbHelperHandler(handler?: RouteHandler): RouteHandler {
+  if (handler === undefined) {
+    throw new Error('Named verb helpers require a handler.');
+  }
+
+  return handler;
 }
 
 export const Get = createVerbHelper('GET');

--- a/src/routing/index.ts
+++ b/src/routing/index.ts
@@ -1,4 +1,5 @@
 export { Route } from './route';
+export { Any, Delete, Get, Head, Options, Patch, Post, Put } from './http-verb-helpers';
 export type { RouteDeclaration } from './route';
 export type { HttpMethod } from './http-method';
 export type { RouteOptions } from './route-options';

--- a/tests/function-first-routing.e2e.test.ts
+++ b/tests/function-first-routing.e2e.test.ts
@@ -1,7 +1,7 @@
 import { text } from 'node:stream/consumers';
 import { describe, expect, test } from 'vitest';
 import { createTestAgent, type HttpRequest, type HttpScope, type UploadedFile } from '../src';
-import { Route } from '../src/routing';
+import { Any, Get, Route } from '../src/routing';
 import { exclusiveRoutingModeError } from '../src/routing/verify-routing-mode';
 
 interface FunctionFirstRoutingRequest extends HttpRequest {
@@ -216,5 +216,36 @@ describe('Function First Routing E2E Test', () => {
         ],
       }),
     ).toThrow(exclusiveRoutingModeError);
+  });
+
+  test('it should dispatch routes declared with a verb helper', async () => {
+    const agent = createTestAgent({
+      routes: [
+        Get('/users', async (scope: HttpScope) => {
+          scope.response.body = [{ id: 1 }];
+        }),
+      ],
+    });
+
+    const response = await agent.get('/users');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual([{ id: 1 }]);
+  });
+
+  test('it should dispatch routes declared with the any helper', async () => {
+    const agent = createTestAgent({
+      routes: [
+        Any('/users', async (scope: HttpScope) => {
+          scope.response.body = { method: scope.request.method };
+        }),
+      ],
+    });
+
+    const patchResponse = await agent.patch('/users');
+    const deleteResponse = await agent.delete('/users');
+
+    expect(patchResponse.body).toEqual({ method: 'PATCH' });
+    expect(deleteResponse.body).toEqual({ method: 'DELETE' });
   });
 });

--- a/tests/function-first-routing.e2e.test.ts
+++ b/tests/function-first-routing.e2e.test.ts
@@ -233,6 +233,21 @@ describe('Function First Routing E2E Test', () => {
     expect(response.body).toEqual([{ id: 1 }]);
   });
 
+  test('it should keep the route name when using a named verb helper', async () => {
+    const agent = createTestAgent({
+      routes: [
+        Get('/users', 'users.list', async (scope: HttpScope) => {
+          scope.response.body = [{ id: 1 }];
+        }),
+      ],
+    });
+
+    const response = await agent.get('/users');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual([{ id: 1 }]);
+  });
+
   test('it should dispatch routes declared with the any helper', async () => {
     const agent = createTestAgent({
       routes: [

--- a/tests/function-first-routing.e2e.test.ts
+++ b/tests/function-first-routing.e2e.test.ts
@@ -1,6 +1,7 @@
 import { text } from 'node:stream/consumers';
 import { describe, expect, test } from 'vitest';
 import { createTestAgent, type HttpRequest, type HttpScope, type UploadedFile } from '../src';
+import { koalaDefaultConfig } from '../src/Config';
 import { Any, Get, Route } from '../src/routing';
 import { exclusiveRoutingModeError } from '../src/routing/verify-routing-mode';
 
@@ -220,6 +221,7 @@ describe('Function First Routing E2E Test', () => {
 
   test('it should dispatch routes declared with a verb helper', async () => {
     const agent = createTestAgent({
+      ...koalaDefaultConfig,
       routes: [
         Get('/users', async (scope: HttpScope) => {
           scope.response.body = [{ id: 1 }];
@@ -235,6 +237,7 @@ describe('Function First Routing E2E Test', () => {
 
   test('it should keep the route name when using a named verb helper', async () => {
     const agent = createTestAgent({
+      ...koalaDefaultConfig,
       routes: [
         Get('/users', 'users.list', async (scope: HttpScope) => {
           scope.response.body = [{ id: 1 }];
@@ -250,6 +253,7 @@ describe('Function First Routing E2E Test', () => {
 
   test('it should dispatch routes declared with the any helper', async () => {
     const agent = createTestAgent({
+      ...koalaDefaultConfig,
       routes: [
         Any('/users', async (scope: HttpScope) => {
           scope.response.body = { method: scope.request.method };


### PR DESCRIPTION
| Q       | A                      |
| ------- | ---------------------- |
| License | GPLv3                  |
| Issue   | Closes #138 |

## Summary

This PR adds HTTP verb helpers to the function-first routing API exposed from `@koala-ts/framework/routing`.

These helpers provide a shorter declaration style for common routes while keeping `Route({...})` as the canonical full route contract.

## Documentation

Documentation updates are covered in the docs PR:

[koala-ts/koala-ts.github.io#11](https://github.com/koala-ts/koala-ts.github.io/pull/11)