### PR TITLE
feat(routing): validate duplicate modern routes

### DIFF
--- a/src/routing/register-routes.test.ts
+++ b/src/routing/register-routes.test.ts
@@ -102,4 +102,29 @@ describe('register routes', () => {
       ]),
     ).toThrow('Duplicate route signature detected: GET /users.');
   });
+
+  test('it rejects duplicate route names', () => {
+    const app = new Koa() as Application;
+
+    expect(() =>
+      registerRoutes(app, [
+        Route({
+          name: 'users.list',
+          method: 'GET',
+          path: '/users',
+          handler: async scope => {
+            scope.response.body = [{ id: 1 }];
+          },
+        }),
+        Route({
+          name: 'users.list',
+          method: 'POST',
+          path: '/users',
+          handler: async scope => {
+            scope.response.body = [{ id: 2 }];
+          },
+        }),
+      ]),
+    ).toThrow('Duplicate route name detected: users.list.');
+  });
 });

--- a/src/routing/register-routes.test.ts
+++ b/src/routing/register-routes.test.ts
@@ -79,4 +79,27 @@ describe('register routes', () => {
     expect(response.headers['x-route-middleware']).toBe('applied');
     expect(response.body).toEqual({ bodyType: 'undefined' });
   });
+
+  test('it rejects duplicate route signatures', () => {
+    const app = new Koa() as Application;
+
+    expect(() =>
+      registerRoutes(app, [
+        Route({
+          method: 'GET',
+          path: '/users',
+          handler: async scope => {
+            scope.response.body = [{ id: 1 }];
+          },
+        }),
+        Route({
+          method: 'GET',
+          path: '/users',
+          handler: async scope => {
+            scope.response.body = [{ id: 2 }];
+          },
+        }),
+      ]),
+    ).toThrow('Duplicate route signature detected: GET /users.');
+  });
 });

--- a/src/routing/register-routes.ts
+++ b/src/routing/register-routes.ts
@@ -23,8 +23,11 @@ export function registerRoutes(app: Application, routes: RouteDefinition[] = [])
 
 function createRouter(routes: RouteDefinition[]): RouterInstance {
   const router = new Router();
+  const registrations = expandRouteDefinitions(routes);
 
-  for (const route of expandRouteDefinitions(routes)) {
+  validateUniqueRouteSignatures(registrations);
+
+  for (const route of registrations) {
     router[route.method](route.path, ...(route.middleware as Middleware<DefaultState, DefaultContext & HttpScope>[]));
   }
 
@@ -55,4 +58,18 @@ function resolveRouteMiddleware(route: RouteDefinition): RouteRegistration['midd
   const middlewareStack = [...route.middleware, route.handler];
 
   return route.parseBody ? [koaBody(route.bodyOptions), ...middlewareStack] : middlewareStack;
+}
+
+function validateUniqueRouteSignatures(registrations: RouteRegistration[]): void {
+  const signatures = new Set<string>();
+
+  for (const registration of registrations) {
+    const signature = `${registration.method} ${registration.path}`;
+
+    if (signatures.has(signature)) {
+      throw new Error(`Duplicate route signature detected: ${registration.method.toUpperCase()} ${registration.path}.`);
+    }
+
+    signatures.add(signature);
+  }
 }

--- a/src/routing/register-routes.ts
+++ b/src/routing/register-routes.ts
@@ -25,6 +25,7 @@ function createRouter(routes: RouteDefinition[]): RouterInstance {
   const router = new Router();
   const registrations = expandRouteDefinitions(routes);
 
+  validateUniqueRouteNames(routes);
   validateUniqueRouteSignatures(registrations);
 
   for (const route of registrations) {
@@ -71,5 +72,21 @@ function validateUniqueRouteSignatures(registrations: RouteRegistration[]): void
     }
 
     signatures.add(signature);
+  }
+}
+
+function validateUniqueRouteNames(routes: RouteDefinition[]): void {
+  const routeNames = new Set<string>();
+
+  for (const route of routes) {
+    if (route.name === undefined) {
+      continue;
+    }
+
+    if (routeNames.has(route.name)) {
+      throw new Error(`Duplicate route name detected: ${route.name}.`);
+    }
+
+    routeNames.add(route.name);
   }
 }

--- a/tests/function-first-routing.e2e.test.ts
+++ b/tests/function-first-routing.e2e.test.ts
@@ -267,4 +267,44 @@ describe('Function First Routing E2E Test', () => {
     expect(patchResponse.body).toEqual({ method: 'PATCH' });
     expect(deleteResponse.body).toEqual({ method: 'DELETE' });
   });
+
+  test('it should reject duplicate route signatures through the test agent', () => {
+    expect(() =>
+      createTestAgent({
+        ...koalaDefaultConfig,
+        routes: [
+          Route({
+            method: 'GET',
+            path: '/users',
+            handler: async (scope: HttpScope) => {
+              scope.response.body = [{ id: 1 }];
+            },
+          }),
+          Route({
+            method: 'GET',
+            path: '/users',
+            handler: async (scope: HttpScope) => {
+              scope.response.body = [{ id: 2 }];
+            },
+          }),
+        ],
+      }),
+    ).toThrow('Duplicate route signature detected: GET /users.');
+  });
+
+  test('it should reject duplicate route names through the test agent', () => {
+    expect(() =>
+      createTestAgent({
+        ...koalaDefaultConfig,
+        routes: [
+          Get('/users', 'users.list', async (scope: HttpScope) => {
+            scope.response.body = [{ id: 1 }];
+          }),
+          Get('/admins', 'users.list', async (scope: HttpScope) => {
+            scope.response.body = [{ id: 2 }];
+          }),
+        ],
+      }),
+    ).toThrow('Duplicate route name detected: users.list.');
+  });
 });


### PR DESCRIPTION
| Q       | A                      |
| ------- | ---------------------- |
| License | GPLv3                  |
| Issue   | Closes #142 |

This PR adds fail-fast validation for duplicate modern route registrations.

Function-first routes now reject duplicate method and path combinations, and duplicate route names, before registration happens. This validation applies only to the modern `routes` API and does not change legacy decorator-routing behavior.