### PR TITLE
feat(routing): add route groups

### DIFF
--- a/src/Config/types.ts
+++ b/src/Config/types.ts
@@ -1,7 +1,7 @@
 import { type HttpMiddleware } from '@/Http';
 import { type StaticFilesOptions } from '@/Http/Files';
 import { type EventSubscriber } from '@/Kernel';
-import type { RouteDefinition } from '@/routing/route-definition';
+import type { RouteSource } from '@/routing/route-source';
 
 /**
  * @deprecated Use function-first routes from `@koala-ts/framework/routing` with `KoalaConfig.routes` instead.
@@ -13,7 +13,7 @@ export interface KoalaConfig {
    * @deprecated Use `routes` with `Route` from `@koala-ts/framework/routing` instead.
    */
   controllers: Controller[];
-  routes?: RouteDefinition[];
+  routes?: RouteSource[];
   globalMiddleware?: HttpMiddleware[];
   staticFiles?: StaticFilesOptions;
   eventSubscribers?: Record<string, EventSubscriber | EventSubscriber[]>;

--- a/src/application/create-application.test.ts
+++ b/src/application/create-application.test.ts
@@ -35,9 +35,11 @@ test('create app with grouped routes', () => {
         {
           prefix: '/api',
         },
-        () => [Get('/users', async scope => {
-          scope.response.body = [];
-        })],
+        () => [
+          Get('/users', async scope => {
+            scope.response.body = [];
+          }),
+        ],
       ),
     ],
   });

--- a/src/application/create-application.test.ts
+++ b/src/application/create-application.test.ts
@@ -1,6 +1,6 @@
 import { create } from '@/application/create-application';
 import { koalaDefaultConfig } from '@/Config';
-import { Route } from '@/routing';
+import { Get, Route, RouteGroup } from '@/routing';
 import { exclusiveRoutingModeError } from '@/routing/verify-routing-mode';
 import { expect, test } from 'vitest';
 
@@ -21,6 +21,24 @@ test('create app with explicit routes', () => {
           scope.response.body = [];
         },
       }),
+    ],
+  });
+
+  expect(app).toBeDefined();
+});
+
+test('create app with grouped routes', () => {
+  const app = create({
+    ...koalaDefaultConfig,
+    routes: [
+      RouteGroup(
+        {
+          prefix: '/api',
+        },
+        () => [Get('/users', async scope => {
+          scope.response.body = [];
+        })],
+      ),
     ],
   });
 

--- a/src/routing/create-route-definition.ts
+++ b/src/routing/create-route-definition.ts
@@ -1,6 +1,7 @@
 import type { HttpMiddleware } from '@/Http';
 import type { HttpMethod } from '@/routing/http-method';
 import type { RouteOptions } from '@/routing/route-options';
+import { resolveRouteOptions } from '@/routing/resolve-route-options';
 import type { RouterMethod } from '@/routing/router-method';
 import type { RouteDefinition } from './route-definition';
 
@@ -21,14 +22,15 @@ export function createRouteDefinition({
   middleware = [],
   options = {},
 }: RouteDefinitionInput): RouteDefinition {
+  const routeOptions = resolveRouteOptions(options);
+
   return {
     name,
     path,
     methods: qualifyMethods(method),
     handler,
-    parseBody: options.parseBody ?? true,
     middleware,
-    bodyOptions: extractBodyOptions(options),
+    ...routeOptions,
   };
 }
 
@@ -41,10 +43,4 @@ function qualifyMethods(method: HttpMethod | HttpMethod[]): RouterMethod[] {
   });
 
   return qualifiedMethods.includes('all') ? ['all'] : [...new Set<RouterMethod>(qualifiedMethods)];
-}
-
-function extractBodyOptions(options: RouteOptions): RouteDefinition['bodyOptions'] {
-  const { parseBody: _parseBody, ...bodyOptions } = options;
-
-  return bodyOptions as RouteDefinition['bodyOptions'];
 }

--- a/src/routing/expand-route-definitions.test.ts
+++ b/src/routing/expand-route-definitions.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test, vi } from 'vitest';
+import { expandRouteDefinitions } from './expand-route-definitions';
+
+describe('expand route definitions', () => {
+  test('it expands route definitions into route registrations', () => {
+    const handler = vi.fn(async () => undefined);
+
+    const registrations = expandRouteDefinitions([
+      {
+        path: '/users',
+        methods: ['get', 'post'],
+        handler,
+        middleware: [],
+        parseBody: false,
+        bodyOptions: {},
+      },
+    ]);
+
+    expect(registrations).toEqual([
+      {
+        method: 'get',
+        path: '/users',
+        middleware: [handler],
+      },
+      {
+        method: 'post',
+        path: '/users',
+        middleware: [handler],
+      },
+    ]);
+  });
+
+  test('it prepends koa body middleware when body parsing is enabled', () => {
+    const handler = vi.fn(async () => undefined);
+
+    const registrations = expandRouteDefinitions([
+      {
+        path: '/users',
+        methods: ['post'],
+        handler,
+        middleware: [],
+        parseBody: true,
+        bodyOptions: { multipart: true },
+      },
+    ]);
+
+    expect(registrations).toHaveLength(1);
+
+    const registration = registrations[0];
+    expect(registration).toBeDefined();
+    expect(registration?.middleware).toHaveLength(2);
+    expect(registration?.middleware[1]).toBe(handler);
+  });
+});

--- a/src/routing/expand-route-definitions.ts
+++ b/src/routing/expand-route-definitions.ts
@@ -1,0 +1,29 @@
+import { koaBody } from 'koa-body';
+import type { RouteDefinition } from '@/routing/route-definition';
+import type { RouteRegistration } from '@/routing/route-registration';
+
+export function expandRouteDefinitions(routes: RouteDefinition[]): RouteRegistration[] {
+  const registrations: RouteRegistration[] = [];
+
+  for (const route of routes) {
+    registrations.push(...expandRouteDefinition(route));
+  }
+
+  return registrations;
+}
+
+function expandRouteDefinition(route: RouteDefinition): RouteRegistration[] {
+  const middleware = resolveRouteMiddleware(route);
+
+  return route.methods.map(method => ({
+    method,
+    path: route.path,
+    middleware,
+  }));
+}
+
+function resolveRouteMiddleware(route: RouteDefinition): RouteRegistration['middleware'] {
+  const middlewareStack = [...route.middleware, route.handler];
+
+  return route.parseBody ? [koaBody(route.bodyOptions), ...middlewareStack] : middlewareStack;
+}

--- a/src/routing/index.ts
+++ b/src/routing/index.ts
@@ -1,5 +1,8 @@
 export { Route } from './route';
+export { RouteGroup } from './route-group';
 export { Any, Delete, Get, Head, Options, Patch, Post, Put } from './http-verb-helpers';
 export type { RouteDeclaration } from './route';
+export type { RouteConfigOverlay, RouteGroupDefinition, RouteGroupOptions } from './route-group';
+export type { RouteSource } from './route-source';
 export type { HttpMethod } from './http-method';
 export type { RouteOptions } from './route-options';

--- a/src/routing/normalize-route-sources.test.ts
+++ b/src/routing/normalize-route-sources.test.ts
@@ -144,4 +144,172 @@ describe('normalize route sources', () => {
       },
     ]);
   });
+
+  test('it applies route overlays to direct child routes by local name', () => {
+    const groupMiddleware = vi.fn(async () => undefined);
+    const overlayMiddleware = vi.fn(async () => undefined);
+    const routeMiddleware = vi.fn(async () => undefined);
+    const handler = vi.fn(async () => undefined);
+    const route = Get('/posts', 'create', handler);
+    route.middleware = [routeMiddleware];
+
+    const routes = normalizeRouteSources([
+      RouteGroup(
+        {
+          middleware: [groupMiddleware],
+          routeConfig: {
+            create: {
+              middleware: [overlayMiddleware],
+              options: {
+                multipart: true,
+                parseBody: false,
+              },
+            },
+          },
+        },
+        () => [route],
+      ),
+    ]);
+
+    expect(routes).toEqual([
+      {
+        ...route,
+        middleware: [groupMiddleware, overlayMiddleware, routeMiddleware],
+        parseBody: false,
+        bodyOptions: {
+          multipart: true,
+        },
+      },
+    ]);
+  });
+
+  test('it does not apply parent route overlays to nested child routes', () => {
+    const overlayMiddleware = vi.fn(async () => undefined);
+    const handler = vi.fn(async () => undefined);
+
+    const routes = normalizeRouteSources([
+      RouteGroup(
+        {
+          routeConfig: {
+            create: {
+              middleware: [overlayMiddleware],
+            },
+          },
+        },
+        () => [
+          RouteGroup(
+            {
+              prefix: '/posts',
+            },
+            () => [Get('/', 'create', handler)],
+          ),
+        ],
+      ),
+    ]);
+
+    expect(routes).toEqual([
+      {
+        bodyOptions: {},
+        handler,
+        methods: ['get'],
+        middleware: [],
+        name: 'create',
+        parseBody: true,
+        path: '/posts',
+      },
+    ]);
+  });
+
+  test('it keeps unnamed direct child routes unchanged when route config is present', () => {
+    const overlayMiddleware = vi.fn(async () => undefined);
+    const handler = vi.fn(async () => undefined);
+
+    const routes = normalizeRouteSources([
+      RouteGroup(
+        {
+          routeConfig: {
+            create: {
+              middleware: [overlayMiddleware],
+            },
+          },
+        },
+        () => [Get('/posts', handler)],
+      ),
+    ]);
+
+    expect(routes).toEqual([
+      {
+        bodyOptions: {},
+        handler,
+        methods: ['get'],
+        middleware: [],
+        parseBody: true,
+        path: '/posts',
+      },
+    ]);
+  });
+
+  test('it applies middleware-only route overlays without changing route options', () => {
+    const overlayMiddleware = vi.fn(async () => undefined);
+    const handler = vi.fn(async () => undefined);
+
+    const routes = normalizeRouteSources([
+      RouteGroup(
+        {
+          routeConfig: {
+            create: {
+              middleware: [overlayMiddleware],
+            },
+          },
+        },
+        () => [Get('/posts', 'create', handler)],
+      ),
+    ]);
+
+    expect(routes).toEqual([
+      {
+        bodyOptions: {},
+        handler,
+        methods: ['get'],
+        middleware: [overlayMiddleware],
+        name: 'create',
+        parseBody: true,
+        path: '/posts',
+      },
+    ]);
+  });
+
+  test('it applies options-only route overlays without changing middleware', () => {
+    const handler = vi.fn(async () => undefined);
+
+    const routes = normalizeRouteSources([
+      RouteGroup(
+        {
+          routeConfig: {
+            create: {
+              options: {
+                multipart: true,
+                parseBody: false,
+              },
+            },
+          },
+        },
+        () => [Get('/posts', 'create', handler)],
+      ),
+    ]);
+
+    expect(routes).toEqual([
+      {
+        bodyOptions: {
+          multipart: true,
+        },
+        handler,
+        methods: ['get'],
+        middleware: [],
+        name: 'create',
+        parseBody: false,
+        path: '/posts',
+      },
+    ]);
+  });
 });

--- a/src/routing/normalize-route-sources.test.ts
+++ b/src/routing/normalize-route-sources.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test, vi } from 'vitest';
+import { Get } from './http-verb-helpers';
+import { normalizeRouteSources } from './normalize-route-sources';
+import { RouteGroup } from './route-group';
+
+describe('normalize route sources', () => {
+  test('it composes group prefixes and middleware into child routes', () => {
+    const auth = vi.fn(async () => undefined);
+    const routeMiddleware = vi.fn(async () => undefined);
+    const handler = vi.fn(async () => undefined);
+    const route = Get('/users', handler);
+    route.middleware = [routeMiddleware];
+
+    const routes = normalizeRouteSources([
+      RouteGroup(
+        {
+          prefix: '/api',
+          middleware: [auth],
+        },
+        () => [route],
+      ),
+    ]);
+
+    expect(routes).toEqual([
+      {
+        ...route,
+        path: '/api/users',
+        middleware: [auth, routeMiddleware],
+      },
+    ]);
+  });
+
+  test('it composes nested group prefixes and name prefixes', () => {
+    const handler = vi.fn(async () => undefined);
+
+    const routes = normalizeRouteSources([
+      RouteGroup(
+        {
+          prefix: '/api',
+          namePrefix: 'api.',
+        },
+        () => [
+          RouteGroup(
+            {
+              prefix: '/posts',
+              namePrefix: 'posts.',
+            },
+            () => [Get('/', 'list', handler)],
+          ),
+        ],
+      ),
+    ]);
+
+    expect(routes).toEqual([
+      {
+        bodyOptions: {},
+        handler,
+        methods: ['get'],
+        middleware: [],
+        name: 'api.posts.list',
+        parseBody: true,
+        path: '/api/posts',
+      },
+    ]);
+  });
+
+  test('it keeps the root path when both group prefix and child path are empty roots', () => {
+    const handler = vi.fn(async () => undefined);
+
+    const routes = normalizeRouteSources([
+      RouteGroup(
+        {
+          prefix: '/',
+        },
+        () => [Get('/', handler)],
+      ),
+    ]);
+
+    expect(routes).toEqual([
+      {
+        bodyOptions: {},
+        handler,
+        methods: ['get'],
+        middleware: [],
+        parseBody: true,
+        path: '/',
+      },
+    ]);
+  });
+
+  test('it keeps the normalized group prefix when the child path is empty', () => {
+    const handler = vi.fn(async () => undefined);
+
+    const routes = normalizeRouteSources([
+      RouteGroup(
+        {
+          prefix: '/api/',
+        },
+        () => [
+          {
+            bodyOptions: {},
+            handler,
+            methods: ['get'],
+            middleware: [],
+            parseBody: true,
+            path: '/',
+          },
+        ],
+      ),
+    ]);
+
+    expect(routes).toEqual([
+      {
+        bodyOptions: {},
+        handler,
+        methods: ['get'],
+        middleware: [],
+        parseBody: true,
+        path: '/api',
+      },
+    ]);
+  });
+
+  test('it keeps the parent prefix when a nested group omits its own prefix', () => {
+    const handler = vi.fn(async () => undefined);
+
+    const routes = normalizeRouteSources([
+      RouteGroup(
+        {
+          prefix: '/api',
+        },
+        () => [RouteGroup({}, () => [Get('/users', handler)])],
+      ),
+    ]);
+
+    expect(routes).toEqual([
+      {
+        bodyOptions: {},
+        handler,
+        methods: ['get'],
+        middleware: [],
+        parseBody: true,
+        path: '/api/users',
+      },
+    ]);
+  });
+});

--- a/src/routing/normalize-route-sources.test.ts
+++ b/src/routing/normalize-route-sources.test.ts
@@ -88,6 +88,30 @@ describe('normalize route sources', () => {
     ]);
   });
 
+  test('it treats a root group prefix as no prefix for non-root child paths', () => {
+    const handler = vi.fn(async () => undefined);
+
+    const routes = normalizeRouteSources([
+      RouteGroup(
+        {
+          prefix: '/',
+        },
+        () => [Get('/users', handler)],
+      ),
+    ]);
+
+    expect(routes).toEqual([
+      {
+        bodyOptions: {},
+        handler,
+        methods: ['get'],
+        middleware: [],
+        parseBody: true,
+        path: '/users',
+      },
+    ]);
+  });
+
   test('it keeps the normalized group prefix when the child path is empty', () => {
     const handler = vi.fn(async () => undefined);
 

--- a/src/routing/normalize-route-sources.ts
+++ b/src/routing/normalize-route-sources.ts
@@ -1,5 +1,6 @@
 import type { RouteDefinition } from '@/routing/route-definition';
 import type { RouteGroupDefinition } from '@/routing/route-group';
+import { mergeRouteOptions } from '@/routing/resolve-route-options';
 import type { RouteSource } from '@/routing/route-source';
 
 interface NormalizationContext {
@@ -35,12 +36,15 @@ export function normalizeRouteSources(
 function normalizeRouteGroup(group: RouteGroupDefinition, parentContext: NormalizationContext): RouteDefinition[] {
   const context = createChildContext(group, parentContext);
 
-  return normalizeRouteSources(group.resolveRoutes(), context);
+  return normalizeRouteSources(applyRouteConfig(group.resolveRoutes(), group), context);
 }
 
 function createChildContext(group: RouteGroupDefinition, parentContext: NormalizationContext): NormalizationContext {
   return {
-    prefix: joinRoutePath(parentContext.prefix, group.options.prefix),
+    prefix:
+      group.options.prefix === undefined
+        ? parentContext.prefix
+        : joinRoutePath(parentContext.prefix, group.options.prefix),
     namePrefix: `${parentContext.namePrefix}${group.options.namePrefix ?? ''}`,
     middleware: [...parentContext.middleware, ...(group.options.middleware ?? [])],
   };
@@ -55,13 +59,40 @@ function normalizeRouteDefinition(route: RouteDefinition, context: Normalization
   };
 }
 
+function applyRouteConfig(routeSources: RouteSource[], group: RouteGroupDefinition): RouteSource[] {
+  return routeSources.map(routeSource => {
+    if (isRouteGroupDefinition(routeSource)) {
+      return routeSource;
+    }
+
+    const routeConfig = routeSource.name ? group.options.routeConfig?.[routeSource.name] : undefined;
+
+    if (!routeConfig) {
+      return routeSource;
+    }
+
+    return {
+      ...routeSource,
+      middleware: [...(routeConfig.middleware ?? []), ...routeSource.middleware],
+      ...resolveRouteConfigOptions(routeSource, routeConfig),
+    };
+  });
+}
+
+function resolveRouteConfigOptions(
+  route: RouteDefinition,
+  routeConfig: NonNullable<RouteGroupDefinition['options']['routeConfig']>[string],
+): Partial<Pick<RouteDefinition, 'parseBody' | 'bodyOptions'>> {
+  return routeConfig.options ? mergeRouteOptions(route, routeConfig.options) : {};
+}
+
 function isRouteGroupDefinition(routeSource: RouteSource): routeSource is RouteGroupDefinition {
   return 'kind' in routeSource && routeSource.kind === 'route-group';
 }
 
-function joinRoutePath(prefix: string, path: string | undefined): string {
+function joinRoutePath(prefix: string, path: string): string {
   const normalizedPrefix = trimTrailingSlash(prefix);
-  const normalizedPath = trimLeadingSlash(path ?? '');
+  const normalizedPath = trimLeadingSlash(path);
 
   if (normalizedPrefix === '') {
     return normalizedPath === '' ? '/' : `/${normalizedPath}`;

--- a/src/routing/normalize-route-sources.ts
+++ b/src/routing/normalize-route-sources.ts
@@ -116,5 +116,5 @@ function trimTrailingSlash(value: string): string {
 
   const normalized = value.replace(/\/+$/, '');
 
-  return normalized === '' ? '/' : normalized;
+  return normalized === '' ? '' : normalized;
 }

--- a/src/routing/normalize-route-sources.ts
+++ b/src/routing/normalize-route-sources.ts
@@ -1,0 +1,89 @@
+import type { RouteDefinition } from '@/routing/route-definition';
+import type { RouteGroupDefinition } from '@/routing/route-group';
+import type { RouteSource } from '@/routing/route-source';
+
+interface NormalizationContext {
+  prefix: string;
+  namePrefix: string;
+  middleware: RouteDefinition['middleware'];
+}
+
+const defaultNormalizationContext: NormalizationContext = {
+  prefix: '',
+  namePrefix: '',
+  middleware: [],
+};
+
+export function normalizeRouteSources(
+  routeSources: RouteSource[],
+  context: NormalizationContext = defaultNormalizationContext,
+): RouteDefinition[] {
+  const routes: RouteDefinition[] = [];
+
+  for (const routeSource of routeSources) {
+    if (isRouteGroupDefinition(routeSource)) {
+      routes.push(...normalizeRouteGroup(routeSource, context));
+      continue;
+    }
+
+    routes.push(normalizeRouteDefinition(routeSource, context));
+  }
+
+  return routes;
+}
+
+function normalizeRouteGroup(group: RouteGroupDefinition, parentContext: NormalizationContext): RouteDefinition[] {
+  const context = createChildContext(group, parentContext);
+
+  return normalizeRouteSources(group.resolveRoutes(), context);
+}
+
+function createChildContext(group: RouteGroupDefinition, parentContext: NormalizationContext): NormalizationContext {
+  return {
+    prefix: joinRoutePath(parentContext.prefix, group.options.prefix),
+    namePrefix: `${parentContext.namePrefix}${group.options.namePrefix ?? ''}`,
+    middleware: [...parentContext.middleware, ...(group.options.middleware ?? [])],
+  };
+}
+
+function normalizeRouteDefinition(route: RouteDefinition, context: NormalizationContext): RouteDefinition {
+  return {
+    ...route,
+    path: joinRoutePath(context.prefix, route.path),
+    name: route.name ? `${context.namePrefix}${route.name}` : undefined,
+    middleware: [...context.middleware, ...route.middleware],
+  };
+}
+
+function isRouteGroupDefinition(routeSource: RouteSource): routeSource is RouteGroupDefinition {
+  return 'kind' in routeSource && routeSource.kind === 'route-group';
+}
+
+function joinRoutePath(prefix: string, path: string | undefined): string {
+  const normalizedPrefix = trimTrailingSlash(prefix);
+  const normalizedPath = trimLeadingSlash(path ?? '');
+
+  if (normalizedPrefix === '') {
+    return normalizedPath === '' ? '/' : `/${normalizedPath}`;
+  }
+
+  if (normalizedPath === '') {
+    return normalizedPrefix;
+  }
+
+  return `${normalizedPrefix}/${normalizedPath}`;
+}
+
+function trimLeadingSlash(value: string): string {
+  return value.replace(/^\/+/, '');
+}
+
+function trimTrailingSlash(value: string): string {
+  if (value === '') {
+    return value;
+  }
+
+  const normalized = value.replace(/\/+$/, '');
+
+  return normalized === '' ? '/' : normalized;
+}

--- a/src/routing/register-routes.test.ts
+++ b/src/routing/register-routes.test.ts
@@ -139,9 +139,11 @@ describe('register routes', () => {
           prefix: '/api',
           namePrefix: 'api.',
         },
-        () => [Get('/users', 'users.list', async scope => {
-          scope.response.body = [{ id: 1 }];
-        })],
+        () => [
+          Get('/users', 'users.list', async scope => {
+            scope.response.body = [{ id: 1 }];
+          }),
+        ],
       ),
     ]);
 

--- a/src/routing/register-routes.test.ts
+++ b/src/routing/register-routes.test.ts
@@ -2,7 +2,9 @@ import Koa from 'koa';
 import supertest from 'supertest';
 import { describe, expect, test } from 'vitest';
 import { type Application } from '@/application/application';
+import { Get } from './http-verb-helpers';
 import { registerRoutes } from './register-routes';
+import { RouteGroup } from './route-group';
 import { Route } from './route';
 
 describe('register routes', () => {
@@ -126,5 +128,47 @@ describe('register routes', () => {
         }),
       ]),
     ).toThrow('Duplicate route name detected: users.list.');
+  });
+
+  test('it registers grouped route sources through the modern registrar', async () => {
+    const app = new Koa() as Application;
+
+    registerRoutes(app, [
+      RouteGroup(
+        {
+          prefix: '/api',
+          namePrefix: 'api.',
+        },
+        () => [Get('/users', 'users.list', async scope => {
+          scope.response.body = [{ id: 1 }];
+        })],
+      ),
+    ]);
+
+    const response = await supertest(app.callback()).get('/api/users');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual([{ id: 1 }]);
+  });
+
+  test('it rejects duplicate grouped route signatures after normalization', () => {
+    const app = new Koa() as Application;
+
+    expect(() =>
+      registerRoutes(app, [
+        RouteGroup(
+          {
+            prefix: '/api',
+          },
+          () => [Get('/users', async () => undefined)],
+        ),
+        RouteGroup(
+          {
+            prefix: '/api',
+          },
+          () => [Get('/users', async () => undefined)],
+        ),
+      ]),
+    ).toThrow('Duplicate route signature detected: GET /api/users.');
   });
 });

--- a/src/routing/register-routes.ts
+++ b/src/routing/register-routes.ts
@@ -1,16 +1,10 @@
 import { type Application } from '@/application/application';
 import { type HttpScope } from '@/Http';
+import { expandRouteDefinitions } from '@/routing/expand-route-definitions';
 import type { RouteDefinition } from '@/routing/route-definition';
-import type { RouterMethod } from '@/routing/router-method';
-import { koaBody } from 'koa-body';
+import { validateRouteDefinitions } from '@/routing/validate-route-definitions';
 import { type DefaultContext, type DefaultState, type Middleware } from 'koa';
 import Router, { type RouterInstance } from '@koa/router';
-
-interface RouteRegistration {
-  method: RouterMethod;
-  path: string;
-  middleware: Array<RouteDefinition['middleware'][number] | RouteDefinition['handler']>;
-}
 
 export function registerRoutes(app: Application, routes: RouteDefinition[] = []): Application {
   const router = createRouter(routes);
@@ -25,68 +19,11 @@ function createRouter(routes: RouteDefinition[]): RouterInstance {
   const router = new Router();
   const registrations = expandRouteDefinitions(routes);
 
-  validateUniqueRouteNames(routes);
-  validateUniqueRouteSignatures(registrations);
+  validateRouteDefinitions(routes, registrations);
 
   for (const route of registrations) {
     router[route.method](route.path, ...(route.middleware as Middleware<DefaultState, DefaultContext & HttpScope>[]));
   }
 
   return router;
-}
-
-function expandRouteDefinitions(routes: RouteDefinition[]): RouteRegistration[] {
-  const registrations: RouteRegistration[] = [];
-
-  for (const route of routes) {
-    registrations.push(...expandRouteDefinition(route));
-  }
-
-  return registrations;
-}
-
-function expandRouteDefinition(route: RouteDefinition): RouteRegistration[] {
-  const middleware = resolveRouteMiddleware(route);
-
-  return route.methods.map(method => ({
-    method,
-    path: route.path,
-    middleware,
-  }));
-}
-
-function resolveRouteMiddleware(route: RouteDefinition): RouteRegistration['middleware'] {
-  const middlewareStack = [...route.middleware, route.handler];
-
-  return route.parseBody ? [koaBody(route.bodyOptions), ...middlewareStack] : middlewareStack;
-}
-
-function validateUniqueRouteSignatures(registrations: RouteRegistration[]): void {
-  const signatures = new Set<string>();
-
-  for (const registration of registrations) {
-    const signature = `${registration.method} ${registration.path}`;
-
-    if (signatures.has(signature)) {
-      throw new Error(`Duplicate route signature detected: ${registration.method.toUpperCase()} ${registration.path}.`);
-    }
-
-    signatures.add(signature);
-  }
-}
-
-function validateUniqueRouteNames(routes: RouteDefinition[]): void {
-  const routeNames = new Set<string>();
-
-  for (const route of routes) {
-    if (route.name === undefined) {
-      continue;
-    }
-
-    if (routeNames.has(route.name)) {
-      throw new Error(`Duplicate route name detected: ${route.name}.`);
-    }
-
-    routeNames.add(route.name);
-  }
 }

--- a/src/routing/register-routes.ts
+++ b/src/routing/register-routes.ts
@@ -1,12 +1,13 @@
 import { type Application } from '@/application/application';
 import { type HttpScope } from '@/Http';
 import { expandRouteDefinitions } from '@/routing/expand-route-definitions';
-import type { RouteDefinition } from '@/routing/route-definition';
+import { normalizeRouteSources } from '@/routing/normalize-route-sources';
+import type { RouteSource } from '@/routing/route-source';
 import { validateRouteDefinitions } from '@/routing/validate-route-definitions';
 import { type DefaultContext, type DefaultState, type Middleware } from 'koa';
 import Router, { type RouterInstance } from '@koa/router';
 
-export function registerRoutes(app: Application, routes: RouteDefinition[] = []): Application {
+export function registerRoutes(app: Application, routes: RouteSource[] = []): Application {
   const router = createRouter(routes);
 
   app.use(router.routes() as unknown as Middleware<DefaultState, DefaultContext & HttpScope>);
@@ -15,8 +16,9 @@ export function registerRoutes(app: Application, routes: RouteDefinition[] = [])
   return app;
 }
 
-function createRouter(routes: RouteDefinition[]): RouterInstance {
+function createRouter(routeSources: RouteSource[]): RouterInstance {
   const router = new Router();
+  const routes = normalizeRouteSources(routeSources);
   const registrations = expandRouteDefinitions(routes);
 
   validateRouteDefinitions(routes, registrations);

--- a/src/routing/resolve-route-options.test.ts
+++ b/src/routing/resolve-route-options.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from 'vitest';
+import { mergeRouteOptions, resolveRouteOptions } from './resolve-route-options';
+
+describe('resolve route options', () => {
+  test('it resolves route definition options from route options', () => {
+    const routeOptions = resolveRouteOptions({
+      multipart: true,
+      parseBody: false,
+    });
+
+    expect(routeOptions).toEqual({
+      parseBody: false,
+      bodyOptions: {
+        multipart: true,
+      },
+    });
+  });
+
+  test('it merges overlay options into an existing route definition', () => {
+    const routeOptions = mergeRouteOptions(
+      {
+        path: '/users',
+        methods: ['post'],
+        handler: async () => undefined,
+        middleware: [],
+        parseBody: true,
+        bodyOptions: {
+          jsonLimit: '1mb',
+        },
+      },
+      {
+        multipart: true,
+        parseBody: false,
+      },
+    );
+
+    expect(routeOptions).toEqual({
+      parseBody: false,
+      bodyOptions: {
+        jsonLimit: '1mb',
+        multipart: true,
+      },
+    });
+  });
+
+  test('it keeps the current parse body setting when the overlay omits it', () => {
+    const routeOptions = mergeRouteOptions(
+      {
+        path: '/users',
+        methods: ['post'],
+        handler: async () => undefined,
+        middleware: [],
+        parseBody: false,
+        bodyOptions: {
+          jsonLimit: '1mb',
+        },
+      },
+      {
+        multipart: true,
+      },
+    );
+
+    expect(routeOptions).toEqual({
+      parseBody: false,
+      bodyOptions: {
+        jsonLimit: '1mb',
+        multipart: true,
+      },
+    });
+  });
+});

--- a/src/routing/resolve-route-options.ts
+++ b/src/routing/resolve-route-options.ts
@@ -1,0 +1,28 @@
+import type { RouteDefinition } from '@/routing/route-definition';
+import type { RouteOptions } from '@/routing/route-options';
+
+export function resolveRouteOptions(options: RouteOptions): Pick<RouteDefinition, 'parseBody' | 'bodyOptions'> {
+  return {
+    parseBody: options.parseBody ?? true,
+    bodyOptions: extractBodyOptions(options),
+  };
+}
+
+export function mergeRouteOptions(
+  route: RouteDefinition,
+  options: RouteOptions,
+): Pick<RouteDefinition, 'parseBody' | 'bodyOptions'> {
+  return {
+    parseBody: options.parseBody ?? route.parseBody,
+    bodyOptions: {
+      ...route.bodyOptions,
+      ...extractBodyOptions(options),
+    },
+  };
+}
+
+function extractBodyOptions(options: RouteOptions): RouteDefinition['bodyOptions'] {
+  const { parseBody: _parseBody, ...bodyOptions } = options;
+
+  return bodyOptions as RouteDefinition['bodyOptions'];
+}

--- a/src/routing/route-group.test.ts
+++ b/src/routing/route-group.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'vitest';
+import { Get } from './http-verb-helpers';
+import { RouteGroup } from './route-group';
+
+describe('route group', () => {
+  test('it creates a callback-based route group definition', () => {
+    const group = RouteGroup(
+      {
+        prefix: '/api',
+        namePrefix: 'api.',
+      },
+      () => [Get('/users', 'users.list', async () => undefined)],
+    );
+
+    expect(group.kind).toBe('route-group');
+    expect(group.options).toEqual({
+      prefix: '/api',
+      namePrefix: 'api.',
+    });
+    expect(group.resolveRoutes()).toHaveLength(1);
+  });
+
+  test('it keeps route overlays on the group definition', () => {
+    const group = RouteGroup(
+      {
+        routeConfig: {
+          create: {
+            options: { parseBody: false },
+          },
+        },
+      },
+      () => [],
+    );
+
+    expect(group.options.routeConfig).toEqual({
+      create: {
+        options: { parseBody: false },
+      },
+    });
+  });
+});

--- a/src/routing/route-group.ts
+++ b/src/routing/route-group.ts
@@ -1,0 +1,26 @@
+import type { HttpMiddleware } from '@/Http';
+import type { RouteDeclaration } from '@/routing/route';
+import type { RouteSource } from '@/routing/route-source';
+
+export type RouteConfigOverlay = Pick<RouteDeclaration, 'middleware' | 'options'>;
+
+export interface RouteGroupOptions {
+  prefix?: string;
+  namePrefix?: string;
+  middleware?: HttpMiddleware[];
+  routeConfig?: Record<string, RouteConfigOverlay>;
+}
+
+export interface RouteGroupDefinition {
+  kind: 'route-group';
+  options: RouteGroupOptions;
+  resolveRoutes: () => RouteSource[];
+}
+
+export function RouteGroup(options: RouteGroupOptions, resolveRoutes: () => RouteSource[]): RouteGroupDefinition {
+  return {
+    kind: 'route-group',
+    options,
+    resolveRoutes,
+  };
+}

--- a/src/routing/route-registration.ts
+++ b/src/routing/route-registration.ts
@@ -1,0 +1,8 @@
+import type { RouteDefinition } from '@/routing/route-definition';
+import type { RouterMethod } from '@/routing/router-method';
+
+export interface RouteRegistration {
+  method: RouterMethod;
+  path: string;
+  middleware: Array<RouteDefinition['middleware'][number] | RouteDefinition['handler']>;
+}

--- a/src/routing/route-source.ts
+++ b/src/routing/route-source.ts
@@ -1,0 +1,4 @@
+import type { RouteDefinition } from '@/routing/route-definition';
+import type { RouteGroupDefinition } from '@/routing/route-group';
+
+export type RouteSource = RouteDefinition | RouteGroupDefinition;

--- a/src/routing/validate-route-definitions.test.ts
+++ b/src/routing/validate-route-definitions.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test, vi } from 'vitest';
+import { validateRouteDefinitions } from './validate-route-definitions';
+
+describe('validate route definitions', () => {
+  test('it rejects duplicate route signatures', () => {
+    const handler = vi.fn(async () => undefined);
+
+    expect(() =>
+      validateRouteDefinitions(
+        [
+          {
+            path: '/users',
+            methods: ['get'],
+            handler,
+            middleware: [],
+            parseBody: false,
+            bodyOptions: {},
+          },
+          {
+            path: '/users',
+            methods: ['get'],
+            handler,
+            middleware: [],
+            parseBody: false,
+            bodyOptions: {},
+          },
+        ],
+        [
+          {
+            method: 'get',
+            path: '/users',
+            middleware: [handler],
+          },
+          {
+            method: 'get',
+            path: '/users',
+            middleware: [handler],
+          },
+        ],
+      ),
+    ).toThrow('Duplicate route signature detected: GET /users.');
+  });
+
+  test('it rejects duplicate route names', () => {
+    const handler = vi.fn(async () => undefined);
+
+    expect(() =>
+      validateRouteDefinitions(
+        [
+          {
+            name: 'users.list',
+            path: '/users',
+            methods: ['get'],
+            handler,
+            middleware: [],
+            parseBody: false,
+            bodyOptions: {},
+          },
+          {
+            name: 'users.list',
+            path: '/admins',
+            methods: ['get'],
+            handler,
+            middleware: [],
+            parseBody: false,
+            bodyOptions: {},
+          },
+        ],
+        [
+          {
+            method: 'get',
+            path: '/users',
+            middleware: [handler],
+          },
+          {
+            method: 'get',
+            path: '/admins',
+            middleware: [handler],
+          },
+        ],
+      ),
+    ).toThrow('Duplicate route name detected: users.list.');
+  });
+
+  test('it allows unique route names and signatures', () => {
+    const handler = vi.fn(async () => undefined);
+
+    expect(() =>
+      validateRouteDefinitions(
+        [
+          {
+            name: 'users.list',
+            path: '/users',
+            methods: ['get'],
+            handler,
+            middleware: [],
+            parseBody: false,
+            bodyOptions: {},
+          },
+          {
+            name: 'admins.list',
+            path: '/admins',
+            methods: ['get'],
+            handler,
+            middleware: [],
+            parseBody: false,
+            bodyOptions: {},
+          },
+        ],
+        [
+          {
+            method: 'get',
+            path: '/users',
+            middleware: [handler],
+          },
+          {
+            method: 'get',
+            path: '/admins',
+            middleware: [handler],
+          },
+        ],
+      ),
+    ).not.toThrow();
+  });
+});

--- a/src/routing/validate-route-definitions.ts
+++ b/src/routing/validate-route-definitions.ts
@@ -1,0 +1,37 @@
+import type { RouteDefinition } from '@/routing/route-definition';
+import type { RouteRegistration } from '@/routing/route-registration';
+
+export function validateRouteDefinitions(routes: RouteDefinition[], registrations: RouteRegistration[]): void {
+  validateUniqueRouteNames(routes);
+  validateUniqueRouteSignatures(registrations);
+}
+
+function validateUniqueRouteSignatures(registrations: RouteRegistration[]): void {
+  const signatures = new Set<string>();
+
+  for (const registration of registrations) {
+    const signature = `${registration.method} ${registration.path}`;
+
+    if (signatures.has(signature)) {
+      throw new Error(`Duplicate route signature detected: ${registration.method.toUpperCase()} ${registration.path}.`);
+    }
+
+    signatures.add(signature);
+  }
+}
+
+function validateUniqueRouteNames(routes: RouteDefinition[]): void {
+  const routeNames = new Set<string>();
+
+  for (const route of routes) {
+    if (route.name === undefined) {
+      continue;
+    }
+
+    if (routeNames.has(route.name)) {
+      throw new Error(`Duplicate route name detected: ${route.name}.`);
+    }
+
+    routeNames.add(route.name);
+  }
+}

--- a/tests/function-first-routing.e2e.test.ts
+++ b/tests/function-first-routing.e2e.test.ts
@@ -2,7 +2,7 @@ import { text } from 'node:stream/consumers';
 import { describe, expect, test } from 'vitest';
 import { createTestAgent, type HttpRequest, type HttpScope, type UploadedFile } from '../src';
 import { koalaDefaultConfig } from '../src/Config';
-import { Any, Get, Route } from '../src/routing';
+import { Any, Get, Route, RouteGroup } from '../src/routing';
 import { exclusiveRoutingModeError } from '../src/routing/verify-routing-mode';
 
 interface FunctionFirstRoutingRequest extends HttpRequest {
@@ -306,5 +306,197 @@ describe('Function First Routing E2E Test', () => {
         ],
       }),
     ).toThrow('Duplicate route name detected: users.list.');
+  });
+
+  test('it should dispatch grouped routes through the test agent', async () => {
+    const agent = createTestAgent({
+      ...koalaDefaultConfig,
+      routes: [
+        RouteGroup(
+          {
+            prefix: '/api',
+          },
+          () => [
+            Get('/users', async (scope: HttpScope) => {
+              scope.response.body = [{ id: 1 }];
+            }),
+          ],
+        ),
+      ],
+    });
+
+    const response = await agent.get('/api/users');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual([{ id: 1 }]);
+  });
+
+  test('it should apply grouped middleware before route overlays and route middleware', async () => {
+    const agent = createTestAgent({
+      ...koalaDefaultConfig,
+      routes: [
+        RouteGroup(
+          {
+            prefix: '/api',
+            middleware: [
+              async (scope, next) => {
+                scope.response.append('x-middleware-order', 'group');
+                await next();
+              },
+            ],
+            routeConfig: {
+              create: {
+                middleware: [
+                  async (scope, next) => {
+                    scope.response.append('x-middleware-order', 'overlay');
+                    await next();
+                  },
+                ],
+              },
+            },
+          },
+          () => [
+            Route({
+              name: 'create',
+              method: 'POST',
+              path: '/posts',
+              middleware: [
+                async (scope, next) => {
+                  scope.response.append('x-middleware-order', 'route');
+                  await next();
+                },
+              ],
+              handler: async (scope: HttpScope) => {
+                scope.response.body = { ok: true };
+              },
+            }),
+          ],
+        ),
+      ],
+    });
+
+    const response = await agent.post('/api/posts');
+    const middlewareOrder = response.headers['x-middleware-order']?.split(', ');
+
+    expect(middlewareOrder).toEqual(['group', 'overlay', 'route']);
+    expect(response.body).toEqual({ ok: true });
+  });
+
+  test('it should apply grouped route config to named helper routes', async () => {
+    const agent = createTestAgent({
+      ...koalaDefaultConfig,
+      routes: [
+        RouteGroup(
+          {
+            routeConfig: {
+              upload: {
+                options: { multipart: true },
+              },
+            },
+          },
+          () => [
+            Get('/users', async (scope: HttpScope) => {
+              scope.response.body = [];
+            }),
+            Route({
+              name: 'upload',
+              method: 'POST',
+              path: '/upload-avatar',
+              handler: async (scope: HttpScope) => {
+                const request = scope.request as FunctionFirstRoutingRequest;
+
+                scope.response.body = {
+                  uploadedFileName: request.files.avatar.originalFilename,
+                };
+              },
+            }),
+          ],
+        ),
+      ],
+    });
+
+    const response = await agent.post('/upload-avatar').attach('avatar', 'tests/fixtures/avatar.png');
+
+    expect(response.body).toEqual({
+      uploadedFileName: 'avatar.png',
+    });
+  });
+
+  test('it should compose nested route groups through the test agent', async () => {
+    const agent = createTestAgent({
+      ...koalaDefaultConfig,
+      routes: [
+        RouteGroup(
+          {
+            prefix: '/api',
+            namePrefix: 'api.',
+          },
+          () => [
+            RouteGroup(
+              {
+                prefix: '/posts',
+                namePrefix: 'posts.',
+              },
+              () => [
+                Get('/', 'list', async (scope: HttpScope) => {
+                  scope.response.body = [{ id: 1 }];
+                }),
+              ],
+            ),
+          ],
+        ),
+      ],
+    });
+
+    const response = await agent.get('/api/posts');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual([{ id: 1 }]);
+  });
+
+  test('it should reject duplicate grouped route signatures after flattening', () => {
+    expect(() =>
+      createTestAgent({
+        ...koalaDefaultConfig,
+        routes: [
+          RouteGroup(
+            {
+              prefix: '/api',
+            },
+            () => [Get('/users', async () => undefined)],
+          ),
+          RouteGroup(
+            {
+              prefix: '/api',
+            },
+            () => [Get('/users', async () => undefined)],
+          ),
+        ],
+      }),
+    ).toThrow('Duplicate route signature detected: GET /api/users.');
+  });
+
+  test('it should reject duplicate grouped route names after flattening', () => {
+    expect(() =>
+      createTestAgent({
+        ...koalaDefaultConfig,
+        routes: [
+          RouteGroup(
+            {
+              prefix: '/api',
+              namePrefix: 'api.',
+            },
+            () => [Get('/users', 'users.list', async () => undefined)],
+          ),
+          RouteGroup(
+            {
+              prefix: '/admins',
+              namePrefix: 'api.',
+            },
+            () => [Get('/users', 'users.list', async () => undefined)],
+          ),
+        ],
+      }),
+    ).toThrow('Duplicate route name detected: api.users.list.');
   });
 });


### PR DESCRIPTION
| Q       | A                      |
| ------- | ---------------------- |
| License | GPLv3                  |
| Issue   | Closes #140  |

## Summary

This PR adds `RouteGroup(...)` to the function-first routing API.

Route groups make it possible to compose routes with shared path prefixes, name prefixes, middleware, and route-level configuration while keeping the routing model explicit and function-first. They also provide a clean way to enrich named helper routes without expanding the HTTP verb helper signatures.

## Documentation

Documentation updates are covered in the docs PR:

[koala-ts/koala-ts.github.io#12](https://github.com/koala-ts/koala-ts.github.io/pull/12)