### PR TITLE
feat(routing): support helper middleware

### DIFF
--- a/src/routing/helpers/http-verb-helpers.test.ts
+++ b/src/routing/helpers/http-verb-helpers.test.ts
@@ -51,9 +51,38 @@ describe('routing http verb helpers', () => {
     });
   });
 
+  test('it creates an unnamed route with middleware before the handler', () => {
+    const firstMiddleware = vi.fn(async () => undefined);
+    const secondMiddleware = vi.fn(async () => undefined);
+    const handler = vi.fn(async () => undefined);
+
+    const route = Get('/users', firstMiddleware, secondMiddleware, handler);
+
+    expect(route.handler).toBe(handler);
+    expect(route.middleware).toEqual([firstMiddleware, secondMiddleware]);
+  });
+
+  test('it creates a named route with middleware before the handler', () => {
+    const firstMiddleware = vi.fn(async () => undefined);
+    const secondMiddleware = vi.fn(async () => undefined);
+    const handler = vi.fn(async () => undefined);
+
+    const route = Get('/users', 'users.list', firstMiddleware, secondMiddleware, handler);
+
+    expect(route.name).toBe('users.list');
+    expect(route.handler).toBe(handler);
+    expect(route.middleware).toEqual([firstMiddleware, secondMiddleware]);
+  });
+
   test('it rejects a named helper call without a handler', () => {
     const get = Get as unknown as (path: string, name: string) => unknown;
 
     expect(() => get('/users', 'users.list')).toThrow('Named verb helpers require a handler.');
+  });
+
+  test('it rejects an unnamed helper call without a handler', () => {
+    const get = Get as unknown as (path: string) => unknown;
+
+    expect(() => get('/users')).toThrow('Verb helpers require a handler.');
   });
 });

--- a/src/routing/helpers/http-verb-helpers.ts
+++ b/src/routing/helpers/http-verb-helpers.ts
@@ -4,44 +4,66 @@ import type { RouteDefinition } from '@/routing/definition/route-definition';
 import { Route } from '@/routing/route';
 
 type RouteHandler = HttpMiddleware;
+type MiddlewareAndHandler = [...middleware: HttpMiddleware[], handler: RouteHandler];
+type NamedMiddlewareAndHandler = [name: string, ...middlewareAndHandler: MiddlewareAndHandler];
+type VerbHelperRouteArguments = MiddlewareAndHandler | NamedMiddlewareAndHandler;
+type UnsafeVerbHelperRouteArguments = VerbHelperRouteArguments | [name: string] | [];
+
 interface VerbHelperArguments {
   path: string;
   name?: string;
+  middleware: HttpMiddleware[];
   handler: RouteHandler;
 }
 
 type NamedVerbHelper = {
-  (path: string, handler: RouteHandler): RouteDefinition;
-  (path: string, name: string, handler: RouteHandler): RouteDefinition;
+  (path: string, ...middlewareAndHandler: MiddlewareAndHandler): RouteDefinition;
+  (path: string, name: string, ...middlewareAndHandler: MiddlewareAndHandler): RouteDefinition;
 };
 
 function createVerbHelper(method: HttpMethod): NamedVerbHelper {
-  return (path: string, nameOrHandler: string | RouteHandler, maybeHandler?: RouteHandler) =>
+  return (path: string, ...routeArguments: UnsafeVerbHelperRouteArguments) =>
     Route({
       method,
-      ...resolveVerbHelperArguments(path, nameOrHandler, maybeHandler),
+      ...resolveVerbHelperArguments(path, routeArguments),
     });
 }
 
-function resolveVerbHelperArguments(
-  path: string,
-  nameOrHandler: string | RouteHandler,
-  maybeHandler?: RouteHandler,
-): VerbHelperArguments {
-  const isNamedRoute = typeof nameOrHandler === 'string';
-  const name = isNamedRoute ? nameOrHandler : undefined;
-  const handler = isNamedRoute ? requireNamedVerbHelperHandler(maybeHandler) : nameOrHandler;
+function resolveVerbHelperArguments(path: string, routeArguments: UnsafeVerbHelperRouteArguments): VerbHelperArguments {
+  const isNamedRoute = isNamedVerbHelperRouteArguments(routeArguments);
+  const name = isNamedRoute ? routeArguments[0] : undefined;
+  const routeMiddlewareAndHandler = isNamedRoute
+    ? (routeArguments.slice(1) as MiddlewareAndHandler | [])
+    : routeArguments;
+  const handler = requireVerbHelperHandler(routeMiddlewareAndHandler, isNamedRoute);
+  const middleware = routeMiddlewareAndHandler.slice(0, -1) as HttpMiddleware[];
 
   return {
     path,
     name,
+    middleware,
     handler,
   };
 }
 
-function requireNamedVerbHelperHandler(handler?: RouteHandler): RouteHandler {
-  if (handler === undefined) {
+function isNamedVerbHelperRouteArguments(
+  routeArguments: UnsafeVerbHelperRouteArguments,
+): routeArguments is NamedMiddlewareAndHandler | [name: string] {
+  return typeof routeArguments[0] === 'string';
+}
+
+function requireVerbHelperHandler(
+  middlewareAndHandler: MiddlewareAndHandler | [],
+  isNamedRoute: boolean,
+): RouteHandler {
+  const handler = middlewareAndHandler.at(-1) as RouteHandler | undefined;
+
+  if (handler === undefined && isNamedRoute) {
     throw new Error('Named verb helpers require a handler.');
+  }
+
+  if (handler === undefined) {
+    throw new Error('Verb helpers require a handler.');
   }
 
   return handler;

--- a/tests/function-first-routing.e2e.test.ts
+++ b/tests/function-first-routing.e2e.test.ts
@@ -1,8 +1,9 @@
 import { text } from 'node:stream/consumers';
 import { describe, expect, test } from 'vitest';
-import { createTestAgent, type HttpRequest, type HttpScope, type UploadedFile } from '../src';
 import { koalaDefaultConfig } from '../src/config/default-config';
-import { Any, Get, Route, RouteGroup } from '../src/routing';
+import type { HttpMiddleware, HttpRequest, HttpScope, NextMiddleware, UploadedFile } from '../src/Http';
+import { Any, Get, Post, Route, RouteGroup } from '../src/routing';
+import { createTestAgent } from '../src/Testing';
 import { exclusiveRoutingModeError } from '../src/routing/verify-routing-mode';
 
 interface FunctionFirstRoutingRequest extends HttpRequest {
@@ -37,7 +38,7 @@ describe('Function First Routing E2E Test', () => {
     const agent = createTestAgent({
       controllers: [],
       globalMiddleware: [
-        async (scope, next) => {
+        async (scope: HttpScope, next: NextMiddleware) => {
           scope.response.set('x-global-middleware', 'applied');
           await next();
         },
@@ -109,7 +110,7 @@ describe('Function First Routing E2E Test', () => {
           method: 'GET',
           path: '/users',
           middleware: [
-            async (scope, next) => {
+            async (scope: HttpScope, next: NextMiddleware) => {
               scope.response.set('x-route-middleware', 'applied');
               await next();
             },
@@ -251,6 +252,31 @@ describe('Function First Routing E2E Test', () => {
     expect(response.body).toEqual([{ id: 1 }]);
   });
 
+  test('it should apply middleware declared through a verb helper in order', async () => {
+    const authMiddleware: HttpMiddleware = async (scope: HttpScope, next: NextMiddleware) => {
+      scope.response.append('x-middleware-order', 'auth');
+      await next();
+    };
+    const auditMiddleware: HttpMiddleware = async (scope: HttpScope, next: NextMiddleware) => {
+      scope.response.append('x-middleware-order', 'audit');
+      await next();
+    };
+    const agent = createTestAgent({
+      ...koalaDefaultConfig,
+      routes: [
+        Get('/users', authMiddleware, auditMiddleware, async (scope: HttpScope) => {
+          scope.response.body = { ok: true };
+        }),
+      ],
+    });
+
+    const response = await agent.get('/users');
+
+    expect(response.status).toBe(200);
+    expect(response.headers['x-middleware-order']?.split(', ')).toEqual(['auth', 'audit']);
+    expect(response.body).toEqual({ ok: true });
+  });
+
   test('it should dispatch routes declared with the any helper', async () => {
     const agent = createTestAgent({
       ...koalaDefaultConfig,
@@ -339,7 +365,7 @@ describe('Function First Routing E2E Test', () => {
           {
             prefix: '/api',
             middleware: [
-              async (scope, next) => {
+              async (scope: HttpScope, next: NextMiddleware) => {
                 scope.response.append('x-middleware-order', 'group');
                 await next();
               },
@@ -347,7 +373,7 @@ describe('Function First Routing E2E Test', () => {
             routeConfig: {
               create: {
                 middleware: [
-                  async (scope, next) => {
+                  async (scope: HttpScope, next: NextMiddleware) => {
                     scope.response.append('x-middleware-order', 'overlay');
                     await next();
                   },
@@ -361,7 +387,7 @@ describe('Function First Routing E2E Test', () => {
               method: 'POST',
               path: '/posts',
               middleware: [
-                async (scope, next) => {
+                async (scope: HttpScope, next: NextMiddleware) => {
                   scope.response.append('x-middleware-order', 'route');
                   await next();
                 },
@@ -395,20 +421,12 @@ describe('Function First Routing E2E Test', () => {
             },
           },
           () => [
-            Get('/users', async (scope: HttpScope) => {
-              scope.response.body = [];
-            }),
-            Route({
-              name: 'upload',
-              method: 'POST',
-              path: '/upload-avatar',
-              handler: async (scope: HttpScope) => {
-                const request = scope.request as FunctionFirstRoutingRequest;
+            Post('/upload-avatar', 'upload', async (scope: HttpScope) => {
+              const request = scope.request as FunctionFirstRoutingRequest;
 
-                scope.response.body = {
-                  uploadedFileName: request.files.avatar.originalFilename,
-                };
-              },
+              scope.response.body = {
+                uploadedFileName: request.files.avatar.originalFilename,
+              };
             }),
           ],
         ),


### PR DESCRIPTION
| Q       | A           |
| ------- | ----------- |
| License | GPLv3       |
| Issue   | Closes #159 |

## Summary

Adds middleware support to function-first HTTP verb helpers.

HTTP helpers now accept zero or more middleware functions before the final handler, for both named and unnamed routes:

- `Get('/users', authMiddleware, handler)`
- `Get('/users', 'users.list', authMiddleware, handler)`

The final function argument is treated as the handler. Any preceding functions after the optional route name are treated as route middleware and run before the handler in declaration order.
