### PR TITLE
feat(validator): Add type validator constraint

### DIFF
--- a/src/validator/constraint-validator.ts
+++ b/src/validator/constraint-validator.ts
@@ -2,7 +2,7 @@ import { Violation } from './violation';
 import { ConstraintOptions } from './constraint';
 import { FieldSchema } from './schema';
 
-export type ConstraintContext<TOptions extends ConstraintOptions = ConstraintOptions> = {
+export type ConstraintContext<TOptions extends ConstraintOptions<object> = ConstraintOptions> = {
   path: string;
   root: unknown;
   value: unknown;
@@ -11,7 +11,7 @@ export type ConstraintContext<TOptions extends ConstraintOptions = ConstraintOpt
   runNestedRules: (value: unknown, schema: FieldSchema, path: string) => Violation[];
 };
 
-export type ConstraintValidator<TOptions extends ConstraintOptions = ConstraintOptions> = (
+export type ConstraintValidator<TOptions extends ConstraintOptions<object> = ConstraintOptions> = (
   value: unknown,
   context: ConstraintContext<TOptions>,
 ) => Violation[];

--- a/src/validator/constraint.ts
+++ b/src/validator/constraint.ts
@@ -1,6 +1,5 @@
-export type ConstraintOptions = {
+export type ConstraintOptions<TOptions extends object = { [option: string]: unknown }> = TOptions & {
   groups?: string[];
-  [key: string]: unknown;
 };
 
 export type ConstraintSchema = {

--- a/src/validator/constraints/basic/not-blank.ts
+++ b/src/validator/constraints/basic/not-blank.ts
@@ -3,10 +3,10 @@ import { ConstraintContext } from '@/validator/constraint-validator';
 
 const DEFAULT_MESSAGE = 'This value should not be blank.';
 
-type NotBlankOptions = ConstraintOptions & {
+type NotBlankOptions = ConstraintOptions<{
   message?: string;
   normalizer?: (value: string) => string;
-};
+}>;
 
 export function notBlank(value: unknown, context: ConstraintContext<NotBlankOptions>) {
   const options = context.options;

--- a/src/validator/constraints/basic/type.test.ts
+++ b/src/validator/constraints/basic/type.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { type, TypeOptions } from './type';
+import { AllowedTypes, type, TypeOptions } from './type';
 import { ConstraintContext } from '@/validator/constraint-validator';
 
 describe('type', () => {
@@ -20,7 +20,7 @@ describe('type', () => {
       root: { name: value },
       value,
       constraint: 'type',
-      options: { type: expectedType },
+      options: { type: expectedType as AllowedTypes },
       runNestedRules: () => [],
     };
 
@@ -52,7 +52,7 @@ describe('type', () => {
       root: { name: value },
       value,
       constraint: 'type',
-      options: { type: expectedType },
+      options: { type: expectedType as AllowedTypes },
       runNestedRules: () => [],
     };
 
@@ -67,7 +67,7 @@ describe('type', () => {
       root: { name: undefined },
       value: undefined,
       constraint: 'type',
-      options: { type: 'undefined' },
+      options: { type: 'number' },
       runNestedRules: () => [],
     };
 

--- a/src/validator/constraints/basic/type.test.ts
+++ b/src/validator/constraints/basic/type.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { ConstraintContext } from '../../types';
-import { type as typeConstraint } from './type';
+import { type } from './type';
 
 describe('type', () => {
   it.each([
@@ -24,7 +24,7 @@ describe('type', () => {
       runNestedRules: () => [],
     };
 
-    const violations = typeConstraint(value, context);
+    const violations = type(value, context);
 
     expect(violations).toHaveLength(1);
     expect(violations[0]).toEqual({
@@ -56,7 +56,7 @@ describe('type', () => {
       runNestedRules: () => [],
     };
 
-    const violations = typeConstraint(value, context);
+    const violations = type(value, context);
 
     expect(violations).toHaveLength(0);
   });
@@ -71,7 +71,7 @@ describe('type', () => {
       runNestedRules: () => [],
     };
 
-    const violations = typeConstraint(42, context);
+    const violations = type(42, context);
 
     expect(violations).toHaveLength(0);
   });
@@ -86,7 +86,7 @@ describe('type', () => {
       runNestedRules: () => [],
     };
 
-    const violations = typeConstraint(false, context);
+    const violations = type(false, context);
 
     expect(violations).toHaveLength(1);
     expect(violations[0]).toEqual({
@@ -107,7 +107,7 @@ describe('type', () => {
       runNestedRules: () => [],
     };
 
-    const violations = typeConstraint(undefined, context);
+    const violations = type(undefined, context);
 
     expect(violations).toHaveLength(0);
   });
@@ -122,7 +122,7 @@ describe('type', () => {
       runNestedRules: () => [],
     };
 
-    const violations = typeConstraint('42', context);
+    const violations = type('42', context);
 
     expect(violations).toHaveLength(1);
     expect(violations[0]).toEqual({

--- a/src/validator/constraints/basic/type.test.ts
+++ b/src/validator/constraints/basic/type.test.ts
@@ -30,7 +30,7 @@ describe('type', () => {
     expect(violations[0]).toEqual({
       path: 'name',
       constraint: 'type',
-      message: `This value should be of type ${expectedType}.`,
+      message: `This value should match at least one of these types [${expectedType}].`,
       value,
     });
   });

--- a/src/validator/constraints/basic/type.test.ts
+++ b/src/validator/constraints/basic/type.test.ts
@@ -1,6 +1,6 @@
-import { ConstraintContext } from '@/validator/constraint-validator';
 import { describe, expect, it } from 'vitest';
 import { type, TypeOptions } from './type';
+import { ConstraintContext } from '@/validator/constraint-validator';
 
 describe('type', () => {
   it.each([

--- a/src/validator/constraints/basic/type.test.ts
+++ b/src/validator/constraints/basic/type.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest';
-import { AllowedType, type, TypeOptions } from './type';
 import { ConstraintContext } from '@/validator/constraint-validator';
+import { describe, expect, it } from 'vitest';
+import { type, TypeOptions } from './type';
 
 describe('type', () => {
   it.each([
@@ -13,15 +13,8 @@ describe('type', () => {
     { expectedType: 'object', value: ['Koala'] },
     { expectedType: 'array', value: { name: 'Koala' } },
     { expectedType: 'null', value: { name: 'Koala' } },
-  ])('returns a violation when the value does not match $expectedType', ({ expectedType, value }) => {
-    const context: ConstraintContext<TypeOptions> = {
-      path: 'name',
-      root: { name: value },
-      value,
-      constraint: 'type',
-      options: { type: expectedType as AllowedType },
-      runNestedRules: () => [],
-    };
+  ] as const)('returns a violation when the value does not match $expectedType', ({ expectedType, value }) => {
+    const context = createContext('name', value, { type: expectedType });
 
     const violations = type(value, context);
 
@@ -44,15 +37,8 @@ describe('type', () => {
     { expectedType: 'object', value: { name: 'Koala' } },
     { expectedType: 'array', value: ['Koala'] },
     { expectedType: 'null', value: null },
-  ])('returns no violations when the value matches $expectedType', ({ expectedType, value }) => {
-    const context: ConstraintContext<TypeOptions> = {
-      path: 'name',
-      root: { name: value },
-      value,
-      constraint: 'type',
-      options: { type: expectedType as AllowedType },
-      runNestedRules: () => [],
-    };
+  ] as const)('returns no violations when the value matches $expectedType', ({ expectedType, value }) => {
+    const context = createContext('name', value, { type: expectedType });
 
     const violations = type(value, context);
 
@@ -60,14 +46,7 @@ describe('type', () => {
   });
 
   it('it should bypass undefined value', () => {
-    const context: ConstraintContext<TypeOptions> = {
-      path: 'name',
-      root: { name: undefined },
-      value: undefined,
-      constraint: 'type',
-      options: { type: 'number' },
-      runNestedRules: () => [],
-    };
+    const context = createContext('name', undefined, { type: 'number' });
 
     const violations = type(undefined, context);
 
@@ -75,14 +54,7 @@ describe('type', () => {
   });
 
   it('returns no violations when the value matches one expected type', () => {
-    const context: ConstraintContext<TypeOptions> = {
-      path: 'identifier',
-      root: { identifier: 42 },
-      value: 42,
-      constraint: 'type',
-      options: { type: ['string', 'number'] },
-      runNestedRules: () => [],
-    };
+    const context = createContext('identifier', 42, { type: ['string', 'number'] });
 
     const violations = type(42, context);
 
@@ -90,14 +62,7 @@ describe('type', () => {
   });
 
   it('returns a violation with all expected types when no expected type matches', () => {
-    const context: ConstraintContext<TypeOptions> = {
-      path: 'identifier',
-      root: { identifier: false },
-      value: false,
-      constraint: 'type',
-      options: { type: ['string', 'number', 'object'] },
-      runNestedRules: () => [],
-    };
+    const context = createContext('identifier', false, { type: ['string', 'number', 'object'] });
 
     const violations = type(false, context);
 
@@ -111,14 +76,7 @@ describe('type', () => {
   });
 
   it('uses a custom message when provided', () => {
-    const context: ConstraintContext<TypeOptions> = {
-      path: 'age',
-      root: { age: '42' },
-      value: '42',
-      constraint: 'type',
-      options: { type: 'number', message: 'Age must be numeric' },
-      runNestedRules: () => [],
-    };
+    const context = createContext('age', '42', { type: 'number', message: 'Age must be numeric' });
 
     const violations = type('42', context);
 
@@ -131,3 +89,14 @@ describe('type', () => {
     });
   });
 });
+
+function createContext(path: string, value: unknown, options: TypeOptions): ConstraintContext<TypeOptions> {
+  return {
+    path,
+    root: { [path]: value },
+    value,
+    constraint: 'type',
+    options,
+    runNestedRules: () => [],
+  };
+}

--- a/src/validator/constraints/basic/type.test.ts
+++ b/src/validator/constraints/basic/type.test.ts
@@ -60,4 +60,19 @@ describe('type', () => {
 
     expect(violations).toHaveLength(0);
   });
+
+  it('returns no violations when the value matches one expected type', () => {
+    const context: ConstraintContext = {
+      path: 'identifier',
+      root: { identifier: 42 },
+      value: 42,
+      constraint: 'type',
+      options: { type: ['string', 'number'] },
+      runNestedRules: () => [],
+    };
+
+    const violations = typeConstraint(42, context);
+
+    expect(violations).toHaveLength(0);
+  });
 });

--- a/src/validator/constraints/basic/type.test.ts
+++ b/src/validator/constraints/basic/type.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import type { ConstraintContext } from '../../types';
-import { type } from './type';
+import { type, TypeOptions } from './type';
+import { ConstraintContext } from '@/validator/constraint-validator';
 
 describe('type', () => {
   it.each([
@@ -15,7 +15,7 @@ describe('type', () => {
     { expectedType: 'null', value: { name: 'Koala' } },
     { expectedType: 'undefined', value: 'Koala' },
   ])('returns a violation when the value does not match $expectedType', ({ expectedType, value }) => {
-    const context: ConstraintContext = {
+    const context: ConstraintContext<TypeOptions> = {
       path: 'name',
       root: { name: value },
       value,
@@ -47,7 +47,7 @@ describe('type', () => {
     { expectedType: 'null', value: null },
     { expectedType: 'undefined', value: undefined },
   ])('returns no violations when the value matches $expectedType', ({ expectedType, value }) => {
-    const context: ConstraintContext = {
+    const context: ConstraintContext<TypeOptions> = {
       path: 'name',
       root: { name: value },
       value,
@@ -62,7 +62,7 @@ describe('type', () => {
   });
 
   it('returns no violations when the value matches one expected type', () => {
-    const context: ConstraintContext = {
+    const context: ConstraintContext<TypeOptions> = {
       path: 'identifier',
       root: { identifier: 42 },
       value: 42,
@@ -77,7 +77,7 @@ describe('type', () => {
   });
 
   it('returns a violation with all expected types when no expected type matches', () => {
-    const context: ConstraintContext = {
+    const context: ConstraintContext<TypeOptions> = {
       path: 'identifier',
       root: { identifier: false },
       value: false,
@@ -98,7 +98,7 @@ describe('type', () => {
   });
 
   it('returns no violations when the value is undefined', () => {
-    const context: ConstraintContext = {
+    const context: ConstraintContext<TypeOptions> = {
       path: 'age',
       root: { age: undefined },
       value: undefined,
@@ -113,7 +113,7 @@ describe('type', () => {
   });
 
   it('uses a custom message when provided', () => {
-    const context: ConstraintContext = {
+    const context: ConstraintContext<TypeOptions> = {
       path: 'age',
       root: { age: '42' },
       value: '42',

--- a/src/validator/constraints/basic/type.test.ts
+++ b/src/validator/constraints/basic/type.test.ts
@@ -61,7 +61,7 @@ describe('type', () => {
     expect(violations).toHaveLength(0);
   });
 
-  it('returns no violations for undefined values', () => {
+  it('returns no violations for undefined value', () => {
     const context: ConstraintContext<TypeOptions> = {
       path: 'name',
       root: { name: undefined },
@@ -110,21 +110,6 @@ describe('type', () => {
       message: 'This value should match at least one of these types [string, number, object].',
       value: false,
     });
-  });
-
-  it('returns no violations when the value is undefined', () => {
-    const context: ConstraintContext<TypeOptions> = {
-      path: 'age',
-      root: { age: undefined },
-      value: undefined,
-      constraint: 'type',
-      options: { type: 'number' },
-      runNestedRules: () => [],
-    };
-
-    const violations = type(undefined, context);
-
-    expect(violations).toHaveLength(0);
   });
 
   it('uses a custom message when provided', () => {

--- a/src/validator/constraints/basic/type.test.ts
+++ b/src/validator/constraints/basic/type.test.ts
@@ -34,4 +34,30 @@ describe('type', () => {
       value,
     });
   });
+
+  it.each([
+    { expectedType: 'string', value: 'Koala' },
+    { expectedType: 'number', value: 42 },
+    { expectedType: 'boolean', value: true },
+    { expectedType: 'bigint', value: 42n },
+    { expectedType: 'symbol', value: Symbol('koala') },
+    { expectedType: 'function', value: () => 'koala' },
+    { expectedType: 'object', value: { name: 'Koala' } },
+    { expectedType: 'array', value: ['Koala'] },
+    { expectedType: 'null', value: null },
+    { expectedType: 'undefined', value: undefined },
+  ])('returns no violations when the value matches $expectedType', ({ expectedType, value }) => {
+    const context: ConstraintContext = {
+      path: 'name',
+      root: { name: value },
+      value,
+      constraint: 'type',
+      options: { type: expectedType },
+      runNestedRules: () => [],
+    };
+
+    const violations = typeConstraint(value, context);
+
+    expect(violations).toHaveLength(0);
+  });
 });

--- a/src/validator/constraints/basic/type.test.ts
+++ b/src/validator/constraints/basic/type.test.ts
@@ -82,7 +82,7 @@ describe('type', () => {
       root: { identifier: false },
       value: false,
       constraint: 'type',
-      options: { type: ['string', 'number'] },
+      options: { type: ['string', 'number', 'object'] },
       runNestedRules: () => [],
     };
 
@@ -92,7 +92,7 @@ describe('type', () => {
     expect(violations[0]).toEqual({
       path: 'identifier',
       constraint: 'type',
-      message: 'This value should be of type string or number.',
+      message: 'This value should match at least one of these types [string, number, object].',
       value: false,
     });
   });

--- a/src/validator/constraints/basic/type.test.ts
+++ b/src/validator/constraints/basic/type.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import type { ConstraintContext, ConstraintOptions } from '../../types';
+import { type as typeConstraint } from './type';
+
+describe('type', () => {
+  it('returns no violations when the value matches the expected type', () => {
+    const context = createContext('Koala', { type: 'string' });
+
+    const violations = typeConstraint('Koala', context);
+
+    expect(violations).toHaveLength(0);
+  });
+});
+
+function createContext(value: unknown, options: ConstraintOptions = {}): ConstraintContext {
+  return {
+    path: 'name',
+    root: { name: value },
+    value,
+    constraint: 'type',
+    options,
+    runNestedRules: () => [],
+  };
+}

--- a/src/validator/constraints/basic/type.test.ts
+++ b/src/validator/constraints/basic/type.test.ts
@@ -61,7 +61,7 @@ describe('type', () => {
     expect(violations).toHaveLength(0);
   });
 
-  it('returns no violations for undefined value', () => {
+  it('it should bypass undefined value', () => {
     const context: ConstraintContext<TypeOptions> = {
       path: 'name',
       root: { name: undefined },

--- a/src/validator/constraints/basic/type.test.ts
+++ b/src/validator/constraints/basic/type.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { AllowedTypes, type, TypeOptions } from './type';
+import { AllowedType, type, TypeOptions } from './type';
 import { ConstraintContext } from '@/validator/constraint-validator';
 
 describe('type', () => {
@@ -20,7 +20,7 @@ describe('type', () => {
       root: { name: value },
       value,
       constraint: 'type',
-      options: { type: expectedType as AllowedTypes },
+      options: { type: expectedType as AllowedType },
       runNestedRules: () => [],
     };
 
@@ -52,7 +52,7 @@ describe('type', () => {
       root: { name: value },
       value,
       constraint: 'type',
-      options: { type: expectedType as AllowedTypes },
+      options: { type: expectedType as AllowedType },
       runNestedRules: () => [],
     };
 

--- a/src/validator/constraints/basic/type.test.ts
+++ b/src/validator/constraints/basic/type.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { type, TypeOptions } from './type';
 import { ConstraintContext } from '@/validator/constraint-validator';
-import {email} from "@/validator";
 
 describe('type', () => {
   it.each([

--- a/src/validator/constraints/basic/type.test.ts
+++ b/src/validator/constraints/basic/type.test.ts
@@ -90,4 +90,25 @@ describe('type', () => {
 
     expect(violations).toHaveLength(0);
   });
+
+  it('uses a custom message when provided', () => {
+    const context: ConstraintContext = {
+      path: 'age',
+      root: { age: '42' },
+      value: '42',
+      constraint: 'type',
+      options: { type: 'number', message: 'Age must be numeric' },
+      runNestedRules: () => [],
+    };
+
+    const violations = typeConstraint('42', context);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toEqual({
+      path: 'age',
+      constraint: 'type',
+      message: 'Age must be numeric',
+      value: '42',
+    });
+  });
 });

--- a/src/validator/constraints/basic/type.test.ts
+++ b/src/validator/constraints/basic/type.test.ts
@@ -13,7 +13,6 @@ describe('type', () => {
     { expectedType: 'object', value: ['Koala'] },
     { expectedType: 'array', value: { name: 'Koala' } },
     { expectedType: 'null', value: { name: 'Koala' } },
-    { expectedType: 'undefined', value: 'Koala' },
   ])('returns a violation when the value does not match $expectedType', ({ expectedType, value }) => {
     const context: ConstraintContext<TypeOptions> = {
       path: 'name',
@@ -45,7 +44,6 @@ describe('type', () => {
     { expectedType: 'object', value: { name: 'Koala' } },
     { expectedType: 'array', value: ['Koala'] },
     { expectedType: 'null', value: null },
-    { expectedType: 'undefined', value: undefined },
   ])('returns no violations when the value matches $expectedType', ({ expectedType, value }) => {
     const context: ConstraintContext<TypeOptions> = {
       path: 'name',

--- a/src/validator/constraints/basic/type.test.ts
+++ b/src/validator/constraints/basic/type.test.ts
@@ -76,6 +76,27 @@ describe('type', () => {
     expect(violations).toHaveLength(0);
   });
 
+  it('returns a violation with all expected types when no expected type matches', () => {
+    const context: ConstraintContext = {
+      path: 'identifier',
+      root: { identifier: false },
+      value: false,
+      constraint: 'type',
+      options: { type: ['string', 'number'] },
+      runNestedRules: () => [],
+    };
+
+    const violations = typeConstraint(false, context);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toEqual({
+      path: 'identifier',
+      constraint: 'type',
+      message: 'This value should be of type string or number.',
+      value: false,
+    });
+  });
+
   it('returns no violations when the value is undefined', () => {
     const context: ConstraintContext = {
       path: 'age',

--- a/src/validator/constraints/basic/type.test.ts
+++ b/src/validator/constraints/basic/type.test.ts
@@ -1,24 +1,37 @@
 import { describe, expect, it } from 'vitest';
-import type { ConstraintContext, ConstraintOptions } from '../../types';
+import type { ConstraintContext } from '../../types';
 import { type as typeConstraint } from './type';
 
 describe('type', () => {
-  it('returns no violations when the value matches the expected type', () => {
-    const context = createContext('Koala', { type: 'string' });
+  it.each([
+    { expectedType: 'string', value: 42 },
+    { expectedType: 'number', value: '42' },
+    { expectedType: 'boolean', value: 'true' },
+    { expectedType: 'bigint', value: 42 },
+    { expectedType: 'symbol', value: 'symbol' },
+    { expectedType: 'function', value: 'function' },
+    { expectedType: 'object', value: ['Koala'] },
+    { expectedType: 'array', value: { name: 'Koala' } },
+    { expectedType: 'null', value: { name: 'Koala' } },
+    { expectedType: 'undefined', value: 'Koala' },
+  ])('returns a violation when the value does not match $expectedType', ({ expectedType, value }) => {
+    const context: ConstraintContext = {
+      path: 'name',
+      root: { name: value },
+      value,
+      constraint: 'type',
+      options: { type: expectedType },
+      runNestedRules: () => [],
+    };
 
-    const violations = typeConstraint('Koala', context);
+    const violations = typeConstraint(value, context);
 
-    expect(violations).toHaveLength(0);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toEqual({
+      path: 'name',
+      constraint: 'type',
+      message: `This value should be of type ${expectedType}.`,
+      value,
+    });
   });
 });
-
-function createContext(value: unknown, options: ConstraintOptions = {}): ConstraintContext {
-  return {
-    path: 'name',
-    root: { name: value },
-    value,
-    constraint: 'type',
-    options,
-    runNestedRules: () => [],
-  };
-}

--- a/src/validator/constraints/basic/type.test.ts
+++ b/src/validator/constraints/basic/type.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { type, TypeOptions } from './type';
 import { ConstraintContext } from '@/validator/constraint-validator';
+import {email} from "@/validator";
 
 describe('type', () => {
   it.each([
@@ -57,6 +58,21 @@ describe('type', () => {
     };
 
     const violations = type(value, context);
+
+    expect(violations).toHaveLength(0);
+  });
+
+  it('returns no violations for undefined values', () => {
+    const context: ConstraintContext<TypeOptions> = {
+      path: 'name',
+      root: { name: undefined },
+      value: undefined,
+      constraint: 'type',
+      options: { type: 'undefined' },
+      runNestedRules: () => [],
+    };
+
+    const violations = type(undefined, context);
 
     expect(violations).toHaveLength(0);
   });

--- a/src/validator/constraints/basic/type.test.ts
+++ b/src/validator/constraints/basic/type.test.ts
@@ -75,4 +75,19 @@ describe('type', () => {
 
     expect(violations).toHaveLength(0);
   });
+
+  it('returns no violations when the value is undefined', () => {
+    const context: ConstraintContext = {
+      path: 'age',
+      root: { age: undefined },
+      value: undefined,
+      constraint: 'type',
+      options: { type: 'number' },
+      runNestedRules: () => [],
+    };
+
+    const violations = typeConstraint(undefined, context);
+
+    expect(violations).toHaveLength(0);
+  });
 });

--- a/src/validator/constraints/basic/type.ts
+++ b/src/validator/constraints/basic/type.ts
@@ -3,6 +3,7 @@ import { ConstraintContext } from '@/validator/constraint-validator';
 import { Violation } from '@/validator/violation';
 
 const DEFAULT_MESSAGE = 'This value should be of type {type}.';
+const DEFAULT_MESSAGE_FOR_MULTIPLE_TYPES = 'This value should match at least one of these types [{types}].';
 
 export type TypeOptions = ConstraintOptions & {
   type: string | string[];
@@ -22,7 +23,7 @@ export function type(value: unknown, context: ConstraintContext<TypeOptions>): V
   return [
     {
       path: context.path,
-      message: options.message ?? getDefaultMessageWith(expectedTypes),
+      message: options.message ?? getDefaultMessageWith(options.type),
       constraint: context.constraint,
       value,
     },
@@ -39,6 +40,12 @@ function getValueType(value: unknown): string {
   return typeof value;
 }
 
-function getDefaultMessageWith(expectedTypes: string[]): string {
-  return DEFAULT_MESSAGE.replace('{type}', expectedTypes.join(' or '));
+function getDefaultMessageWith(type: string | string[]): string {
+  const expectedTypes = Array.isArray(type) ? type : [type];
+
+  if (expectedTypes.length > 1) {
+    return DEFAULT_MESSAGE_FOR_MULTIPLE_TYPES.replace('{types}', expectedTypes.join(', '));
+  }
+
+  return DEFAULT_MESSAGE.replace('{type}', expectedTypes[0]);
 }

--- a/src/validator/constraints/basic/type.ts
+++ b/src/validator/constraints/basic/type.ts
@@ -23,7 +23,7 @@ export function type(value: unknown, context: ConstraintContext): Violation[] {
     {
       path: context.path,
       constraint: context.constraint,
-      message: DEFAULT_MESSAGE.replace('{type}', String(options.type)),
+      message: options.message ?? DEFAULT_MESSAGE.replace('{type}', String(options.type)),
       value,
     },
   ];

--- a/src/validator/constraints/basic/type.ts
+++ b/src/validator/constraints/basic/type.ts
@@ -2,8 +2,7 @@ import { ConstraintOptions } from '@/validator/constraint';
 import { ConstraintContext } from '@/validator/constraint-validator';
 import { Violation } from '@/validator/violation';
 
-const DEFAULT_MESSAGE = 'This value should be of type {type}.';
-const DEFAULT_MESSAGE_FOR_MULTIPLE_TYPES = 'This value should match at least one of these types [{types}].';
+const DEFAULT_MESSAGE = 'This value should match at least one of these types [{types}].';
 
 export type AllowedTypes =
   | 'string'
@@ -53,9 +52,5 @@ function getValueType(value: unknown): AllowedTypes {
 }
 
 function getDefaultMessageWith(types: AllowedTypes[]): string {
-  if (types.length === 1) {
-    return DEFAULT_MESSAGE.replace('{type}', types[0] as string);
-  }
-
-  return DEFAULT_MESSAGE_FOR_MULTIPLE_TYPES.replace('{types}', types.join(', '));
+  return DEFAULT_MESSAGE.replace('{types}', types.join(', '));
 }

--- a/src/validator/constraints/basic/type.ts
+++ b/src/validator/constraints/basic/type.ts
@@ -5,7 +5,16 @@ import { Violation } from '@/validator/violation';
 const DEFAULT_MESSAGE = 'This value should be of type {type}.';
 const DEFAULT_MESSAGE_FOR_MULTIPLE_TYPES = 'This value should match at least one of these types [{types}].';
 
-type AllowedTypes = string | number | boolean | bigint | symbol | 'function' | object | 'array' | null | undefined;
+export type AllowedTypes =
+  | 'string'
+  | 'number'
+  | 'boolean'
+  | 'bigint'
+  | 'symbol'
+  | 'function'
+  | 'object'
+  | 'array'
+  | 'null';
 export type TypeOptions = ConstraintOptions & {
   type: AllowedTypes | AllowedTypes[];
   message?: string;
@@ -35,10 +44,10 @@ function matchesExpectedType(value: unknown, expectedTypes: AllowedTypes[]): boo
   return expectedTypes.includes(getValueType(value));
 }
 
-function getValueType(value: unknown): string {
+function getValueType(value: unknown): AllowedTypes {
   if (value === null) return 'null';
   if (Array.isArray(value)) return 'array';
-  return typeof value;
+  return typeof value as AllowedTypes;
 }
 
 function getDefaultMessageWith(types: AllowedTypes[]): string {

--- a/src/validator/constraints/basic/type.ts
+++ b/src/validator/constraints/basic/type.ts
@@ -25,15 +25,16 @@ export function type(value: unknown, context: ConstraintContext<TypeOptions>): V
     return [];
   }
 
-  const options: TypeOptions = context.options;
-  const normalizedTypes: AllowedTypes[] = Array.isArray(options.type) ? options.type : [options.type];
+  const normalizedTypes: AllowedTypes[] = Array.isArray(context.options.type)
+    ? context.options.type
+    : [context.options.type];
 
   if (matchesExpectedType(value, normalizedTypes)) return [];
 
   return [
     {
       path: context.path,
-      message: options.message ?? getDefaultMessageWith(normalizedTypes),
+      message: context.options.message ?? getDefaultMessageWith(normalizedTypes),
       constraint: context.constraint,
       value,
     },

--- a/src/validator/constraints/basic/type.ts
+++ b/src/validator/constraints/basic/type.ts
@@ -12,32 +12,29 @@ export type TypeOptions = ConstraintOptions<{
 }>;
 
 export function type(value: unknown, context: ConstraintContext<TypeOptions>): Violation[] {
-  if (value === undefined) {
-    return [];
-  }
+  if (value === undefined) return [];
 
-  const normalizedTypes: readonly AllowedType[] = Array.isArray(context.options.type)
-    ? context.options.type
-    : [context.options.type];
+  const actualType = getTypeOf(value);
+  const expectedTypes = getExpectedTypes(context.options.type);
 
-  if (normalizedTypes.includes(getTypeOf(value))) return [];
+  if (expectedTypes.includes(actualType)) return [];
 
   return [
     {
       path: context.path,
-      message: context.options.message ?? getDefaultMessageWith(normalizedTypes),
+      message: context.options.message ?? DEFAULT_MESSAGE.replace('{types}', expectedTypes.join(', ')),
       constraint: context.constraint,
       value,
     },
   ];
 }
 
-function getTypeOf(value: unknown): AllowedType {
+function getTypeOf(value: unknown): string {
   if (value === null) return 'null';
   if (Array.isArray(value)) return 'array';
-  return typeof value as AllowedType;
+  return typeof value;
 }
 
-function getDefaultMessageWith(types: readonly AllowedType[]): string {
-  return DEFAULT_MESSAGE.replace('{types}', types.join(', '));
+function getExpectedTypes(type: TypeOptions['type']): readonly AllowedType[] {
+  return typeof type === 'string' ? [type] : type;
 }

--- a/src/validator/constraints/basic/type.ts
+++ b/src/validator/constraints/basic/type.ts
@@ -1,25 +1,21 @@
 import type { ConstraintContext, ConstraintOptions, Violation } from '../../types';
 
+const DEFAULT_MESSAGE = 'This value should be of type {type}.';
+
 export type TypeOptions = ConstraintOptions & {
   type: string | string[];
   message?: string;
 };
 
-function typeConstraint(value: unknown, context: ConstraintContext): Violation[] {
+export function type(value: unknown, context: ConstraintContext): Violation[] {
   const options = context.options as TypeOptions;
-
-  if (typeof value === options.type) {
-    return [];
-  }
 
   return [
     {
       path: context.path,
       constraint: context.constraint,
-      message: 'This value should be of type string.',
+      message: DEFAULT_MESSAGE.replace('{type}', String(options.type)),
       value,
     },
   ];
 }
-
-export { typeConstraint as type };

--- a/src/validator/constraints/basic/type.ts
+++ b/src/validator/constraints/basic/type.ts
@@ -29,7 +29,7 @@ export function type(value: unknown, context: ConstraintContext<TypeOptions>): V
     ? context.options.type
     : [context.options.type];
 
-  if (matchesExpectedType(value, normalizedTypes)) return [];
+  if (normalizedTypes.includes(getTypeOf(value))) return [];
 
   return [
     {
@@ -41,11 +41,7 @@ export function type(value: unknown, context: ConstraintContext<TypeOptions>): V
   ];
 }
 
-function matchesExpectedType(value: unknown, expectedTypes: AllowedTypes[]): boolean {
-  return expectedTypes.includes(getValueType(value));
-}
-
-function getValueType(value: unknown): AllowedTypes {
+function getTypeOf(value: unknown): AllowedTypes {
   if (value === null) return 'null';
   if (Array.isArray(value)) return 'array';
   return typeof value as AllowedTypes;

--- a/src/validator/constraints/basic/type.ts
+++ b/src/validator/constraints/basic/type.ts
@@ -23,7 +23,7 @@ export function type(value: unknown, context: ConstraintContext): Violation[] {
     {
       path: context.path,
       constraint: context.constraint,
-      message: options.message ?? DEFAULT_MESSAGE.replace('{type}', String(options.type)),
+      message: options.message ?? DEFAULT_MESSAGE.replace('{type}', formatExpectedTypes(expectedTypes)),
       value,
     },
   ];
@@ -39,4 +39,8 @@ function getValueType(value: unknown): string {
   }
 
   return typeof value;
+}
+
+function formatExpectedTypes(expectedTypes: string[]): string {
+  return expectedTypes.join(' or ');
 }

--- a/src/validator/constraints/basic/type.ts
+++ b/src/validator/constraints/basic/type.ts
@@ -42,9 +42,9 @@ function getValueType(value: unknown): string {
 }
 
 function getDefaultMessageWith(types: AllowedTypes[]): string {
-  if (Array.isArray(types) && types.length > 1) {
-    return DEFAULT_MESSAGE_FOR_MULTIPLE_TYPES.replace('{types}', types.join(', '));
+  if (types.length === 1) {
+    return DEFAULT_MESSAGE.replace('{type}', types[0] as string);
   }
 
-  return DEFAULT_MESSAGE.replace('{type}', types[0] as string);
+  return DEFAULT_MESSAGE_FOR_MULTIPLE_TYPES.replace('{types}', types.join(', '));
 }

--- a/src/validator/constraints/basic/type.ts
+++ b/src/validator/constraints/basic/type.ts
@@ -4,28 +4,21 @@ import { Violation } from '@/validator/violation';
 
 const DEFAULT_MESSAGE = 'This value should match at least one of these types [{types}].';
 
-export type AllowedType =
-  | 'string'
-  | 'number'
-  | 'boolean'
-  | 'bigint'
-  | 'symbol'
-  | 'function'
-  | 'object'
-  | 'array'
-  | 'null';
+type AllowedType = 'string' | 'number' | 'boolean' | 'bigint' | 'symbol' | 'function' | 'object' | 'array' | 'null';
 
-export type TypeOptions = ConstraintOptions & {
-  type: AllowedType | AllowedType[];
+export type TypeOptions = ConstraintOptions<{
+  type: AllowedType | readonly AllowedType[];
   message?: string;
-};
+}>;
 
 export function type(value: unknown, context: ConstraintContext<TypeOptions>): Violation[] {
   if (value === undefined) {
     return [];
   }
 
-  const normalizedTypes: AllowedType[] = [context.options.type].flat();
+  const normalizedTypes: readonly AllowedType[] = Array.isArray(context.options.type)
+    ? context.options.type
+    : [context.options.type];
 
   if (normalizedTypes.includes(getTypeOf(value))) return [];
 
@@ -45,6 +38,6 @@ function getTypeOf(value: unknown): AllowedType {
   return typeof value as AllowedType;
 }
 
-function getDefaultMessageWith(types: AllowedType[]): string {
+function getDefaultMessageWith(types: readonly AllowedType[]): string {
   return DEFAULT_MESSAGE.replace('{types}', types.join(', '));
 }

--- a/src/validator/constraints/basic/type.ts
+++ b/src/validator/constraints/basic/type.ts
@@ -15,6 +15,7 @@ export type AllowedTypes =
   | 'object'
   | 'array'
   | 'null';
+
 export type TypeOptions = ConstraintOptions & {
   type: AllowedTypes | AllowedTypes[];
   message?: string;

--- a/src/validator/constraints/basic/type.ts
+++ b/src/validator/constraints/basic/type.ts
@@ -17,7 +17,7 @@ export function type(value: unknown, context: ConstraintContext<TypeOptions>): V
   const actualType = getTypeOf(value);
   const expectedTypes = getExpectedTypes(context.options.type);
 
-  if (expectedTypes.includes(actualType)) return [];
+  if (expectedTypes.some(expectedType => actualType === expectedType)) return [];
 
   return [
     {

--- a/src/validator/constraints/basic/type.ts
+++ b/src/validator/constraints/basic/type.ts
@@ -4,9 +4,10 @@ import { Violation } from '@/validator/violation';
 
 const DEFAULT_MESSAGE = 'This value should be of type {type}.';
 const DEFAULT_MESSAGE_FOR_MULTIPLE_TYPES = 'This value should match at least one of these types [{types}].';
+type AllowedTypes = string | number | boolean | bigint | symbol | 'function' | object | 'array' | null | undefined;
 
 export type TypeOptions = ConstraintOptions & {
-  type: string | string[];
+  type: AllowedTypes | AllowedTypes[];
   message?: string;
 };
 
@@ -15,22 +16,22 @@ export function type(value: unknown, context: ConstraintContext<TypeOptions>): V
     return [];
   }
 
-  const options = context.options;
-  const expectedTypes = Array.isArray(options.type) ? options.type : [options.type];
+  const options: TypeOptions = context.options;
+  const normalizedTypes: AllowedTypes[] = Array.isArray(options.type) ? options.type : [options.type];
 
-  if (matchesExpectedType(value, expectedTypes)) return [];
+  if (matchesExpectedType(value, normalizedTypes)) return [];
 
   return [
     {
       path: context.path,
-      message: options.message ?? getDefaultMessageWith(expectedTypes),
+      message: options.message ?? getDefaultMessageWith(normalizedTypes),
       constraint: context.constraint,
       value,
     },
   ];
 }
 
-function matchesExpectedType(value: unknown, expectedTypes: string[]): boolean {
+function matchesExpectedType(value: unknown, expectedTypes: AllowedTypes[]): boolean {
   return expectedTypes.includes(getValueType(value));
 }
 
@@ -40,7 +41,7 @@ function getValueType(value: unknown): string {
   return typeof value;
 }
 
-function getDefaultMessageWith(types: string[]): string {
+function getDefaultMessageWith(types: AllowedTypes[]): string {
   if (Array.isArray(types) && types.length > 1) {
     return DEFAULT_MESSAGE_FOR_MULTIPLE_TYPES.replace('{types}', types.join(', '));
   }

--- a/src/validator/constraints/basic/type.ts
+++ b/src/validator/constraints/basic/type.ts
@@ -2,45 +2,41 @@ import type { ConstraintContext, ConstraintOptions, Violation } from '../../type
 
 const DEFAULT_MESSAGE = 'This value should be of type {type}.';
 
-export type TypeOptions = ConstraintOptions & {
+type TypeOptions = ConstraintOptions & {
   type: string | string[];
   message?: string;
 };
 
 export function type(value: unknown, context: ConstraintContext): Violation[] {
-  const options = context.options as TypeOptions;
-  const expectedTypes = Array.isArray(options.type) ? options.type : [options.type];
-
   if (value === undefined) {
     return [];
   }
 
-  if (expectedTypes.includes(getValueType(value))) {
-    return [];
-  }
+  const options = context.options as TypeOptions;
+  const expectedTypes = Array.isArray(options.type) ? options.type : [options.type];
+
+  if (matchesExpectedType(value, expectedTypes)) return [];
 
   return [
     {
       path: context.path,
       constraint: context.constraint,
-      message: options.message ?? DEFAULT_MESSAGE.replace('{type}', formatExpectedTypes(expectedTypes)),
+      message: options.message ?? getDefaultMessageWith(expectedTypes),
       value,
     },
   ];
 }
 
+function matchesExpectedType(value: unknown, expectedTypes: string[]): boolean {
+  return expectedTypes.includes(getValueType(value));
+}
+
 function getValueType(value: unknown): string {
-  if (value === null) {
-    return 'null';
-  }
-
-  if (Array.isArray(value)) {
-    return 'array';
-  }
-
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'array';
   return typeof value;
 }
 
-function formatExpectedTypes(expectedTypes: string[]): string {
-  return expectedTypes.join(' or ');
+function getDefaultMessageWith(expectedTypes: string[]): string {
+  return DEFAULT_MESSAGE.replace('{type}', expectedTypes.join(' or '));
 }

--- a/src/validator/constraints/basic/type.ts
+++ b/src/validator/constraints/basic/type.ts
@@ -9,8 +9,9 @@ export type TypeOptions = ConstraintOptions & {
 
 export function type(value: unknown, context: ConstraintContext): Violation[] {
   const options = context.options as TypeOptions;
+  const expectedTypes = Array.isArray(options.type) ? options.type : [options.type];
 
-  if (getValueType(value) === options.type) {
+  if (expectedTypes.includes(getValueType(value))) {
     return [];
   }
 

--- a/src/validator/constraints/basic/type.ts
+++ b/src/validator/constraints/basic/type.ts
@@ -4,8 +4,8 @@ import { Violation } from '@/validator/violation';
 
 const DEFAULT_MESSAGE = 'This value should be of type {type}.';
 const DEFAULT_MESSAGE_FOR_MULTIPLE_TYPES = 'This value should match at least one of these types [{types}].';
-type AllowedTypes = string | number | boolean | bigint | symbol | 'function' | object | 'array' | null | undefined;
 
+type AllowedTypes = string | number | boolean | bigint | symbol | 'function' | object | 'array' | null | undefined;
 export type TypeOptions = ConstraintOptions & {
   type: AllowedTypes | AllowedTypes[];
   message?: string;

--- a/src/validator/constraints/basic/type.ts
+++ b/src/validator/constraints/basic/type.ts
@@ -23,7 +23,7 @@ export function type(value: unknown, context: ConstraintContext<TypeOptions>): V
   return [
     {
       path: context.path,
-      message: options.message ?? getDefaultMessageWith(options.type),
+      message: options.message ?? getDefaultMessageWith(expectedTypes),
       constraint: context.constraint,
       value,
     },
@@ -40,12 +40,10 @@ function getValueType(value: unknown): string {
   return typeof value;
 }
 
-function getDefaultMessageWith(type: string | string[]): string {
-  const expectedTypes = Array.isArray(type) ? type : [type];
-
-  if (expectedTypes.length > 1) {
-    return DEFAULT_MESSAGE_FOR_MULTIPLE_TYPES.replace('{types}', expectedTypes.join(', '));
+function getDefaultMessageWith(types: string[]): string {
+  if (Array.isArray(types) && types.length > 1) {
+    return DEFAULT_MESSAGE_FOR_MULTIPLE_TYPES.replace('{types}', types.join(', '));
   }
 
-  return DEFAULT_MESSAGE.replace('{type}', expectedTypes[0]);
+  return DEFAULT_MESSAGE.replace('{type}', types[0] as string);
 }

--- a/src/validator/constraints/basic/type.ts
+++ b/src/validator/constraints/basic/type.ts
@@ -1,18 +1,20 @@
-import type { ConstraintContext, ConstraintOptions, Violation } from '../../types';
+import { ConstraintOptions } from '@/validator/constraint';
+import { ConstraintContext } from '@/validator/constraint-validator';
+import { Violation } from '@/validator/violation';
 
 const DEFAULT_MESSAGE = 'This value should be of type {type}.';
 
-type TypeOptions = ConstraintOptions & {
+export type TypeOptions = ConstraintOptions & {
   type: string | string[];
   message?: string;
 };
 
-export function type(value: unknown, context: ConstraintContext): Violation[] {
+export function type(value: unknown, context: ConstraintContext<TypeOptions>): Violation[] {
   if (value === undefined) {
     return [];
   }
 
-  const options = context.options as TypeOptions;
+  const options = context.options;
   const expectedTypes = Array.isArray(options.type) ? options.type : [options.type];
 
   if (matchesExpectedType(value, expectedTypes)) return [];
@@ -20,8 +22,8 @@ export function type(value: unknown, context: ConstraintContext): Violation[] {
   return [
     {
       path: context.path,
-      constraint: context.constraint,
       message: options.message ?? getDefaultMessageWith(expectedTypes),
+      constraint: context.constraint,
       value,
     },
   ];

--- a/src/validator/constraints/basic/type.ts
+++ b/src/validator/constraints/basic/type.ts
@@ -1,0 +1,25 @@
+import type { ConstraintContext, ConstraintOptions, Violation } from '../../types';
+
+export type TypeOptions = ConstraintOptions & {
+  type: string | string[];
+  message?: string;
+};
+
+function typeConstraint(value: unknown, context: ConstraintContext): Violation[] {
+  const options = context.options as TypeOptions;
+
+  if (typeof value === options.type) {
+    return [];
+  }
+
+  return [
+    {
+      path: context.path,
+      constraint: context.constraint,
+      message: 'This value should be of type string.',
+      value,
+    },
+  ];
+}
+
+export { typeConstraint as type };

--- a/src/validator/constraints/basic/type.ts
+++ b/src/validator/constraints/basic/type.ts
@@ -10,6 +10,10 @@ export type TypeOptions = ConstraintOptions & {
 export function type(value: unknown, context: ConstraintContext): Violation[] {
   const options = context.options as TypeOptions;
 
+  if (getValueType(value) === options.type) {
+    return [];
+  }
+
   return [
     {
       path: context.path,
@@ -18,4 +22,16 @@ export function type(value: unknown, context: ConstraintContext): Violation[] {
       value,
     },
   ];
+}
+
+function getValueType(value: unknown): string {
+  if (value === null) {
+    return 'null';
+  }
+
+  if (Array.isArray(value)) {
+    return 'array';
+  }
+
+  return typeof value;
 }

--- a/src/validator/constraints/basic/type.ts
+++ b/src/validator/constraints/basic/type.ts
@@ -11,6 +11,10 @@ export function type(value: unknown, context: ConstraintContext): Violation[] {
   const options = context.options as TypeOptions;
   const expectedTypes = Array.isArray(options.type) ? options.type : [options.type];
 
+  if (value === undefined) {
+    return [];
+  }
+
   if (expectedTypes.includes(getValueType(value))) {
     return [];
   }

--- a/src/validator/constraints/basic/type.ts
+++ b/src/validator/constraints/basic/type.ts
@@ -4,7 +4,7 @@ import { Violation } from '@/validator/violation';
 
 const DEFAULT_MESSAGE = 'This value should match at least one of these types [{types}].';
 
-export type AllowedTypes =
+export type AllowedType =
   | 'string'
   | 'number'
   | 'boolean'
@@ -16,7 +16,7 @@ export type AllowedTypes =
   | 'null';
 
 export type TypeOptions = ConstraintOptions & {
-  type: AllowedTypes | AllowedTypes[];
+  type: AllowedType | AllowedType[];
   message?: string;
 };
 
@@ -25,7 +25,7 @@ export function type(value: unknown, context: ConstraintContext<TypeOptions>): V
     return [];
   }
 
-  const normalizedTypes: AllowedTypes[] = Array.isArray(context.options.type)
+  const normalizedTypes: AllowedType[] = Array.isArray(context.options.type)
     ? context.options.type
     : [context.options.type];
 
@@ -41,12 +41,12 @@ export function type(value: unknown, context: ConstraintContext<TypeOptions>): V
   ];
 }
 
-function getTypeOf(value: unknown): AllowedTypes {
+function getTypeOf(value: unknown): AllowedType {
   if (value === null) return 'null';
   if (Array.isArray(value)) return 'array';
-  return typeof value as AllowedTypes;
+  return typeof value as AllowedType;
 }
 
-function getDefaultMessageWith(types: AllowedTypes[]): string {
+function getDefaultMessageWith(types: AllowedType[]): string {
   return DEFAULT_MESSAGE.replace('{types}', types.join(', '));
 }

--- a/src/validator/constraints/basic/type.ts
+++ b/src/validator/constraints/basic/type.ts
@@ -25,9 +25,7 @@ export function type(value: unknown, context: ConstraintContext<TypeOptions>): V
     return [];
   }
 
-  const normalizedTypes: AllowedType[] = Array.isArray(context.options.type)
-    ? context.options.type
-    : [context.options.type];
+  const normalizedTypes: AllowedType[] = [context.options.type].flat();
 
   if (normalizedTypes.includes(getTypeOf(value))) return [];
 

--- a/src/validator/constraints/index.ts
+++ b/src/validator/constraints/index.ts
@@ -1,7 +1,7 @@
 import { notBlank } from '@/validator/constraints/basic/not-blank';
 import { email } from '@/validator/constraints/string/email';
 import { slug } from '@/validator/constraints/string/slug';
-import {type} from "@/validator/constraints/basic/type";
+import { type } from '@/validator/constraints/basic/type';
 
 export const builtInConstraints = {
   // Basic

--- a/src/validator/constraints/index.ts
+++ b/src/validator/constraints/index.ts
@@ -1,10 +1,12 @@
 import { notBlank } from '@/validator/constraints/basic/not-blank';
 import { email } from '@/validator/constraints/string/email';
 import { slug } from '@/validator/constraints/string/slug';
+import {type} from "@/validator/constraints/basic/type";
 
 export const builtInConstraints = {
   // Basic
   notBlank,
+  type,
 
   // String
   email,
@@ -14,4 +16,5 @@ export const builtInConstraints = {
 export * from './string/email';
 export * from './string/slug';
 export * from './basic/not-blank';
+export * from './basic/type';
 export * from './other/compound';

--- a/src/validator/constraints/string/email.ts
+++ b/src/validator/constraints/string/email.ts
@@ -3,10 +3,10 @@ import { ConstraintContext } from '@/validator/constraint-validator';
 
 const DEFAULT_MESSAGE = 'This value is not a valid email address.';
 
-type EmailOptions = ConstraintOptions & {
+type EmailOptions = ConstraintOptions<{
   message?: string;
   normalizer?: (value: string) => string;
-};
+}>;
 
 const strictEmailRegex = /^[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+$/;
 

--- a/src/validator/constraints/string/slug.ts
+++ b/src/validator/constraints/string/slug.ts
@@ -3,10 +3,10 @@ import { ConstraintContext } from '@/validator/constraint-validator';
 
 const DEFAULT_MESSAGE = 'This value is not a valid slug.';
 
-type SlugOptions = ConstraintOptions & {
+type SlugOptions = ConstraintOptions<{
   message?: string;
   normalizer?: (value: string) => string;
-};
+}>;
 
 const strictSlugRegex = /^(?!-)(?!.*--)[a-z0-9]+(?:-[a-z0-9]+)*$/;
 


### PR DESCRIPTION
### Overview

In this PR, I have introduced new validation constraint called type. 
```ts
type TypeOptions = ConstraintOptions & {
  type: AllowedTypes | AllowedTypes[];
  message?: string;
};
```
```ts
export type AllowedTypes =
  | 'string'
  | 'number'
  | 'boolean'
  | 'bigint'
  | 'symbol'
  | 'function'
  | 'object'
  | 'array'
  | 'null';
```

It's exposed through the `builtInConstraints`   and can be used like 
```ts
const rules = {
  age: [{ type: { type: 'number' } }],
  identifier: [{ type: { type: ['string', 'number'] } }],
}
```

- Main purpose of this constraint is to validate whether the given value matches the expected type or one of the expected types.
- This constraint is concerned about the type of the given value and should work as a required constraint, which means  is the value is undefined the constraint will return no violations.
- Last point doesn't applied for the `null` as `null` is a real value. 

### Changes made: 
1. Added the `type` constraint under basic constraint. 
2. Covered the required cases in `type.test` file. 
3. Exposed the `type` constraint through the `builtInConstraints` object.


| Q       | A                      |
| ------- | ---------------------- |
| License | GPLv3                  |
| Issue   | Closes #169 > |
