### PR TITLE
chore(validator):  use generic template for  `ConstraintOptions` across validator constraint option types

### DIFF
--- a/src/validator/constraint-validator.ts
+++ b/src/validator/constraint-validator.ts
@@ -2,12 +2,12 @@ import { Violation } from './violation';
 import { ConstraintOptions } from './constraint';
 import { FieldSchema } from './schema';
 
-export type ConstraintContext = {
+export type ConstraintContext<TOptions extends ConstraintOptions = ConstraintOptions> = {
   path: string;
   root: unknown;
   value: unknown;
   constraint: string;
-  options: ConstraintOptions;
+  options: TOptions;
   runNestedRules: (value: unknown, schema: FieldSchema, path: string) => Violation[];
 };
 

--- a/src/validator/constraint-validator.ts
+++ b/src/validator/constraint-validator.ts
@@ -11,4 +11,7 @@ export type ConstraintContext<TOptions extends ConstraintOptions = ConstraintOpt
   runNestedRules: (value: unknown, schema: FieldSchema, path: string) => Violation[];
 };
 
-export type ConstraintValidator = (value: unknown, context: ConstraintContext) => Violation[];
+export type ConstraintValidator<TOptions extends ConstraintOptions = ConstraintOptions> = (
+  value: unknown,
+  context: ConstraintContext<TOptions>,
+) => Violation[];

--- a/src/validator/constraints/basic/not-blank.test.ts
+++ b/src/validator/constraints/basic/not-blank.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { notBlank } from './not-blank';
-import { ConstraintContext } from '../../constraint-validator';
+import { ConstraintContext } from '@/validator/constraint-validator';
 
 describe('notBlank', () => {
   it.each([

--- a/src/validator/constraints/basic/not-blank.ts
+++ b/src/validator/constraints/basic/not-blank.ts
@@ -1,5 +1,5 @@
 import { ConstraintOptions } from '@/validator';
-import { ConstraintValidator } from '@/validator';
+import { ConstraintContext } from '@/validator';
 
 const DEFAULT_MESSAGE = 'This value should not be blank.';
 
@@ -8,7 +8,7 @@ type NotBlankOptions = ConstraintOptions & {
   normalizer?: (value: string) => string;
 };
 
-export const notBlank: ConstraintValidator<NotBlankOptions> = (value, context) => {
+export function notBlank(value: unknown, context: ConstraintContext<NotBlankOptions>) {
   const options = context.options;
   const message = options.message ?? DEFAULT_MESSAGE;
 
@@ -27,7 +27,7 @@ export const notBlank: ConstraintValidator<NotBlankOptions> = (value, context) =
   }
 
   return [];
-};
+}
 
 function isBlank(value: unknown): boolean {
   return value === '' || value === null || value === undefined || (Array.isArray(value) && value.length === 0);

--- a/src/validator/constraints/basic/not-blank.ts
+++ b/src/validator/constraints/basic/not-blank.ts
@@ -1,5 +1,5 @@
-import { ConstraintOptions } from '@/validator';
-import { ConstraintContext } from '@/validator';
+import { ConstraintOptions } from '@/validator/constraint';
+import { ConstraintContext } from '@/validator/constraint-validator';
 
 const DEFAULT_MESSAGE = 'This value should not be blank.';
 

--- a/src/validator/constraints/basic/not-blank.ts
+++ b/src/validator/constraints/basic/not-blank.ts
@@ -1,6 +1,6 @@
 import { Violation } from '@/validator/violation';
 import { ConstraintOptions } from '../../constraint';
-import { ConstraintContext } from '../../constraint-validator';
+import { ConstraintValidator } from '../../constraint-validator';
 
 const DEFAULT_MESSAGE = 'This value should not be blank.';
 
@@ -9,8 +9,8 @@ type NotBlankOptions = ConstraintOptions & {
   normalizer?: (value: string) => string;
 };
 
-export function notBlank(value: unknown, context: ConstraintContext): Violation[] {
-  const options = context.options as NotBlankOptions;
+export const notBlank: ConstraintValidator<NotBlankOptions> = (value, context) => {
+  const options = context.options;
   const message = options.message ?? DEFAULT_MESSAGE;
 
   const normalizedValue =
@@ -28,7 +28,7 @@ export function notBlank(value: unknown, context: ConstraintContext): Violation[
   }
 
   return [];
-}
+};
 
 function isBlank(value: unknown): boolean {
   return value === '' || value === null || value === undefined || (Array.isArray(value) && value.length === 0);

--- a/src/validator/constraints/basic/not-blank.ts
+++ b/src/validator/constraints/basic/not-blank.ts
@@ -1,9 +1,10 @@
 import { Violation } from '@/validator/violation';
+import { ConstraintOptions } from '../../constraint';
 import { ConstraintContext } from '../../constraint-validator';
 
 const DEFAULT_MESSAGE = 'This value should not be blank.';
 
-type NotBlankOptions = {
+type NotBlankOptions = ConstraintOptions & {
   message?: string;
   normalizer?: (value: string) => string;
 };

--- a/src/validator/constraints/basic/not-blank.ts
+++ b/src/validator/constraints/basic/not-blank.ts
@@ -1,6 +1,5 @@
-import { Violation } from '@/validator/violation';
-import { ConstraintOptions } from '../../constraint';
-import { ConstraintValidator } from '../../constraint-validator';
+import { ConstraintOptions } from '@/validator';
+import { ConstraintValidator } from '@/validator';
 
 const DEFAULT_MESSAGE = 'This value should not be blank.';
 

--- a/src/validator/constraints/index.ts
+++ b/src/validator/constraints/index.ts
@@ -1,6 +1,6 @@
-import { notBlank } from './basic/not-blank';
-import { email } from './string/email';
-import { slug } from './string/slug';
+import { notBlank } from '@/validator/constraints/basic/not-blank';
+import { email } from '@/validator/constraints/string/email';
+import { slug } from '@/validator/constraints/string/slug';
 
 export const builtInConstraints = {
   // Basic

--- a/src/validator/constraints/other/compound.integration.test.ts
+++ b/src/validator/constraints/other/compound.integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { createValidator } from '@/validator/factory/create-validator';
-import { notBlank } from '../basic/not-blank';
-import { email } from '../string/email';
+import { notBlank } from '@/validator/constraints/basic/not-blank';
+import { email } from '@/validator/constraints/string/email';
 import { compound } from './compound';
 
 describe('compound (integration)', () => {

--- a/src/validator/constraints/other/compound.test.ts
+++ b/src/validator/constraints/other/compound.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { compound } from './compound';
 import { Violation } from '@/validator/violation';
-import { ConstraintContext } from '../../constraint-validator';
+import { ConstraintContext } from '@/validator/constraint-validator';
 
 describe('compound', () => {
   it('creates a constraint that applies nested constraints from arrays', () => {

--- a/src/validator/constraints/other/compound.ts
+++ b/src/validator/constraints/other/compound.ts
@@ -1,5 +1,5 @@
 import { Violation } from '@/validator/violation';
-import { ConstraintContext } from '../../constraint-validator';
+import { ConstraintContext } from '@/validator';
 import { FieldSchema } from '@/validator/schema';
 
 export function compound(schema: FieldSchema) {

--- a/src/validator/constraints/other/compound.ts
+++ b/src/validator/constraints/other/compound.ts
@@ -1,6 +1,6 @@
 import { Violation } from '@/validator/violation';
-import { ConstraintContext } from '@/validator';
 import { FieldSchema } from '@/validator/schema';
+import { ConstraintContext } from '@/validator/constraint-validator';
 
 export function compound(schema: FieldSchema) {
   return function compoundConstraint(value: unknown, context: ConstraintContext): Violation[] {

--- a/src/validator/constraints/string/email.test.ts
+++ b/src/validator/constraints/string/email.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { email } from './email';
-import { ConstraintContext } from '../../constraint-validator';
+import { ConstraintContext } from '@/validator/constraint-validator';
 
 describe('email', () => {
   it('rejects invalid email by default', () => {

--- a/src/validator/constraints/string/email.ts
+++ b/src/validator/constraints/string/email.ts
@@ -1,6 +1,5 @@
-import { Violation } from '@/validator/violation';
-import { ConstraintOptions } from '../../constraint';
-import { ConstraintValidator } from '../../constraint-validator';
+import { ConstraintOptions } from '@/validator';
+import { ConstraintValidator } from '@/validator';
 
 const DEFAULT_MESSAGE = 'This value is not a valid email address.';
 

--- a/src/validator/constraints/string/email.ts
+++ b/src/validator/constraints/string/email.ts
@@ -1,5 +1,5 @@
 import { ConstraintOptions } from '@/validator';
-import { ConstraintValidator } from '@/validator';
+import { ConstraintContext } from '@/validator';
 
 const DEFAULT_MESSAGE = 'This value is not a valid email address.';
 
@@ -10,7 +10,7 @@ type EmailOptions = ConstraintOptions & {
 
 const strictEmailRegex = /^[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+$/;
 
-export const email: ConstraintValidator<EmailOptions> = (value, context) => {
+export function email(value: unknown, context: ConstraintContext<EmailOptions>) {
   const options = context.options;
   const message = options.message ?? DEFAULT_MESSAGE;
 
@@ -43,4 +43,4 @@ export const email: ConstraintValidator<EmailOptions> = (value, context) => {
   }
 
   return [];
-};
+}

--- a/src/validator/constraints/string/email.ts
+++ b/src/validator/constraints/string/email.ts
@@ -1,5 +1,5 @@
-import { ConstraintOptions } from '@/validator';
-import { ConstraintContext } from '@/validator';
+import { ConstraintOptions } from '@/validator/constraint';
+import { ConstraintContext } from '@/validator/constraint-validator';
 
 const DEFAULT_MESSAGE = 'This value is not a valid email address.';
 

--- a/src/validator/constraints/string/email.ts
+++ b/src/validator/constraints/string/email.ts
@@ -1,6 +1,6 @@
 import { Violation } from '@/validator/violation';
 import { ConstraintOptions } from '../../constraint';
-import { ConstraintContext } from '../../constraint-validator';
+import { ConstraintValidator } from '../../constraint-validator';
 
 const DEFAULT_MESSAGE = 'This value is not a valid email address.';
 
@@ -11,8 +11,8 @@ type EmailOptions = ConstraintOptions & {
 
 const strictEmailRegex = /^[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+$/;
 
-export function email(value: unknown, context: ConstraintContext): Violation[] {
-  const options = context.options as EmailOptions;
+export const email: ConstraintValidator<EmailOptions> = (value, context) => {
+  const options = context.options;
   const message = options.message ?? DEFAULT_MESSAGE;
 
   if (value === undefined) {
@@ -44,4 +44,4 @@ export function email(value: unknown, context: ConstraintContext): Violation[] {
   }
 
   return [];
-}
+};

--- a/src/validator/constraints/string/email.ts
+++ b/src/validator/constraints/string/email.ts
@@ -1,9 +1,10 @@
 import { Violation } from '@/validator/violation';
+import { ConstraintOptions } from '../../constraint';
 import { ConstraintContext } from '../../constraint-validator';
 
 const DEFAULT_MESSAGE = 'This value is not a valid email address.';
 
-type EmailOptions = {
+type EmailOptions = ConstraintOptions & {
   message?: string;
   normalizer?: (value: string) => string;
 };

--- a/src/validator/constraints/string/slug.test.ts
+++ b/src/validator/constraints/string/slug.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { slug } from './slug';
-import { ConstraintOptions } from '../../constraint';
-import { ConstraintContext } from '../../constraint-validator';
+import { ConstraintOptions } from '@/validator/constraint';
+import { ConstraintContext } from '@/validator/constraint-validator';
 
 describe('slug', () => {
   it('accepts valid slug with lowercase, digits and hyphens', () => {

--- a/src/validator/constraints/string/slug.ts
+++ b/src/validator/constraints/string/slug.ts
@@ -1,5 +1,5 @@
-import { ConstraintOptions } from '@/validator';
-import { ConstraintContext } from '@/validator';
+import { ConstraintOptions } from '@/validator/constraint';
+import { ConstraintContext } from '@/validator/constraint-validator';
 
 const DEFAULT_MESSAGE = 'This value is not a valid slug.';
 

--- a/src/validator/constraints/string/slug.ts
+++ b/src/validator/constraints/string/slug.ts
@@ -1,5 +1,5 @@
 import { ConstraintOptions } from '@/validator';
-import { ConstraintValidator } from '@/validator';
+import { ConstraintContext } from '@/validator';
 
 const DEFAULT_MESSAGE = 'This value is not a valid slug.';
 
@@ -10,7 +10,7 @@ type SlugOptions = ConstraintOptions & {
 
 const strictSlugRegex = /^(?!-)(?!.*--)[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
-export const slug: ConstraintValidator<SlugOptions> = (value, context) => {
+export function slug(value: unknown, context: ConstraintContext<SlugOptions>) {
   const options = context.options;
   const message = options.message ?? DEFAULT_MESSAGE;
 
@@ -43,4 +43,4 @@ export const slug: ConstraintValidator<SlugOptions> = (value, context) => {
   }
 
   return [];
-};
+}

--- a/src/validator/constraints/string/slug.ts
+++ b/src/validator/constraints/string/slug.ts
@@ -1,6 +1,6 @@
 import { Violation } from '@/validator/violation';
 import { ConstraintOptions } from '../../constraint';
-import { ConstraintContext } from '../../constraint-validator';
+import { ConstraintValidator } from '../../constraint-validator';
 
 const DEFAULT_MESSAGE = 'This value is not a valid slug.';
 
@@ -11,8 +11,8 @@ type SlugOptions = ConstraintOptions & {
 
 const strictSlugRegex = /^(?!-)(?!.*--)[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
-export function slug(value: unknown, context: ConstraintContext): Violation[] {
-  const options = context.options as SlugOptions;
+export const slug: ConstraintValidator<SlugOptions> = (value, context) => {
+  const options = context.options;
   const message = options.message ?? DEFAULT_MESSAGE;
 
   if (value === undefined) {
@@ -44,4 +44,4 @@ export function slug(value: unknown, context: ConstraintContext): Violation[] {
   }
 
   return [];
-}
+};

--- a/src/validator/constraints/string/slug.ts
+++ b/src/validator/constraints/string/slug.ts
@@ -1,9 +1,10 @@
 import { Violation } from '@/validator/violation';
+import { ConstraintOptions } from '../../constraint';
 import { ConstraintContext } from '../../constraint-validator';
 
 const DEFAULT_MESSAGE = 'This value is not a valid slug.';
 
-type SlugOptions = {
+type SlugOptions = ConstraintOptions & {
   message?: string;
   normalizer?: (value: string) => string;
 };

--- a/src/validator/constraints/string/slug.ts
+++ b/src/validator/constraints/string/slug.ts
@@ -1,6 +1,5 @@
-import { Violation } from '@/validator/violation';
-import { ConstraintOptions } from '../../constraint';
-import { ConstraintValidator } from '../../constraint-validator';
+import { ConstraintOptions } from '@/validator';
+import { ConstraintValidator } from '@/validator';
 
 const DEFAULT_MESSAGE = 'This value is not a valid slug.';
 

--- a/src/validator/factory/create-validator.test.ts
+++ b/src/validator/factory/create-validator.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { UnknownConstraintError } from '../errors';
-import { createValidator } from './create-validator';
+import { UnknownConstraintError } from '@/validator/errors';
+import { createValidator } from '@/validator/factory/create-validator';
 import { Violation } from '@/validator/violation';
-import { ConstraintContext } from '../constraint-validator';
+import { ConstraintContext } from '@/validator/constraint-validator';
 
 describe('Validator', () => {
   describe('Registry', () => {

--- a/src/validator/factory/create-validator.ts
+++ b/src/validator/factory/create-validator.ts
@@ -1,9 +1,9 @@
-import { UnknownConstraintError } from '../errors';
-import { ConstraintOptions } from '../constraint';
-import { ConstraintContext, ConstraintValidator } from '../constraint-validator';
+import { ConstraintOptions } from '@/validator/constraint';
+import { UnknownConstraintError } from '@/validator/errors';
 import { FieldSchema } from '@/validator/schema';
 import { Validator } from '@/validator/validator';
-import { Payload } from '@/validator';
+import { ConstraintContext, ConstraintValidator } from '@/validator/constraint-validator';
+import { Payload } from '@/validator/payload';
 
 type FieldSchemaEntry = [string, FieldSchema];
 type ConstraintsMap = Record<string, ConstraintValidator>;


### PR DESCRIPTION
| Q       | A                      |
| ------- | ---------------------- |
| License | GPLv3                  |
| Issue   | Closes #168  |

### Overview

This PR introduce a generic template type to be used in the `ConstraintContext` for `ConstraintOptions`.

### Changes made
1. Generalised `ConstraintOptions` in `ConstraintContext`
```ts
export type ConstraintContext<TOptions extends ConstraintOptions = ConstraintOptions> = {
  path: string;
  root: unknown;
  value: unknown;
  constraint: string;
  options: TOptions;
  runNestedRules: (value: unknown, schema: FieldSchema, path: string) => Violation[];
};
```
2. It also affected the `ConstraintValidator` to be 
```ts
export type ConstraintValidator<TOptions extends ConstraintOptions = ConstraintOptions> = (
  value: unknown,
  context: ConstraintContext<TOptions>,
) => Violation[];
```
3. Used the related options type for each constraint validator 
```ts
export function notBlank(value: unknown, context: ConstraintContext<NotBlankOptions>)
```
```ts
export function email(value: unknown, context: ConstraintContext<EmailOptions>) 
```
```ts
export function slug(value: unknown, context: ConstraintContext<SlugOptions>) 
```
### Clarification: 
I did not add dedicated type-only test cases because this change is validated by the TypeScript compiler during npm run build. 
The runtime behavior is unchanged, and the existing behavior tests continue to cover the validator execution path.


