### PR TITLE
feat(validator): add unique validator constraint

### DIFF
--- a/src/validator/constraints/comparison/unique.test.ts
+++ b/src/validator/constraints/comparison/unique.test.ts
@@ -40,4 +40,26 @@ describe('unique', () => {
       value,
     });
   });
+
+  it('uses a custom message when provided', () => {
+    const value = ['admin', 'admin'];
+    const context: ConstraintContext = {
+      path: 'tags',
+      root: { tags: value },
+      value,
+      constraint: 'unique',
+      options: { message: 'Tags must be unique' },
+      runNestedRules: () => [],
+    };
+
+    const violations = unique(value, context);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toEqual({
+      path: 'tags',
+      constraint: 'unique',
+      message: 'Tags must be unique',
+      value,
+    });
+  });
 });

--- a/src/validator/constraints/comparison/unique.test.ts
+++ b/src/validator/constraints/comparison/unique.test.ts
@@ -63,14 +63,14 @@ describe('unique', () => {
     });
   });
 
-  it('returns no violations when the value is undefined', () => {
+  it('should bypass undefined value', () => {
     const value = undefined;
     const context: ConstraintContext = {
       path: 'tags',
       root: {},
       value,
       constraint: 'unique',
-      options: {},
+      options: { message: 'Tags must be unique' },
       runNestedRules: () => [],
     };
 

--- a/src/validator/constraints/comparison/unique.test.ts
+++ b/src/validator/constraints/comparison/unique.test.ts
@@ -15,7 +15,7 @@ describe('unique', () => {
 
     test('validation fails when the value is null', () => {
       const value = null;
-      const context: ConstraintContext = createContext('tags', value, {} as UniqueOptions);
+      const context: ConstraintContext = createContext('tags', value, {});
 
       const violations = unique(value, context);
 
@@ -30,7 +30,7 @@ describe('unique', () => {
 
     test('validation fails when the value is not an array', () => {
       const value = 'admin';
-      const context: ConstraintContext = createContext('tags', value, {} as UniqueOptions);
+      const context: ConstraintContext = createContext('tags', value, {});
 
       const violations = unique(value, context);
 
@@ -47,7 +47,7 @@ describe('unique', () => {
   describe('arrays of scalars', () => {
     test('validation passes when array elements are unique', () => {
       const value = ['7', 7, true, null, undefined];
-      const context: ConstraintContext = createContext('tags', value, {} as UniqueOptions);
+      const context: ConstraintContext = createContext('tags', value, {});
 
       const violations = unique(value, context);
 
@@ -56,7 +56,7 @@ describe('unique', () => {
 
     test('validation passes when the array contains a null value', () => {
       const value = [null];
-      const context: ConstraintContext = createContext('tags', value, {} as UniqueOptions);
+      const context: ConstraintContext = createContext('tags', value, {});
 
       const violations = unique(value, context);
 
@@ -65,7 +65,7 @@ describe('unique', () => {
 
     test('validation passes when the array contains an undefined value', () => {
       const value = [undefined];
-      const context: ConstraintContext = createContext('tags', value, {} as UniqueOptions);
+      const context: ConstraintContext = createContext('tags', value, {});
 
       const violations = unique(value, context);
 
@@ -74,7 +74,7 @@ describe('unique', () => {
 
     test('validation fails when an array contains duplicate null values', () => {
       const value = [null, null];
-      const context: ConstraintContext = createContext('tags', value, {} as UniqueOptions);
+      const context: ConstraintContext = createContext('tags', value, {});
 
       const violations = unique(value, context);
 
@@ -89,7 +89,7 @@ describe('unique', () => {
 
     test('validation fails when an array contains duplicate undefined values', () => {
       const value = [undefined, undefined];
-      const context: ConstraintContext = createContext('tags', value, {} as UniqueOptions);
+      const context: ConstraintContext = createContext('tags', value, {});
 
       const violations = unique(value, context);
 
@@ -104,7 +104,7 @@ describe('unique', () => {
 
     test('validation fails when an array contains duplicate elements', () => {
       const value = ['admin', 'editor', 'admin'];
-      const context: ConstraintContext = createContext('tags', value, {} as UniqueOptions);
+      const context: ConstraintContext = createContext('tags', value, {});
 
       const violations = unique(value, context);
 
@@ -121,7 +121,7 @@ describe('unique', () => {
   describe('arrays of arrays', () => {
     test('validation passes when nested arrays have different values', () => {
       const value = [['admin'], ['editor']];
-      const context: ConstraintContext = createContext('tags', value, {} as UniqueOptions);
+      const context: ConstraintContext = createContext('tags', value, {});
 
       const violations = unique(value, context);
 
@@ -130,7 +130,7 @@ describe('unique', () => {
 
     test('validation fails when nested arrays have the same values', () => {
       const value = [['admin'], ['admin']];
-      const context: ConstraintContext = createContext('tags', value, {} as UniqueOptions);
+      const context: ConstraintContext = createContext('tags', value, {});
 
       const violations = unique(value, context);
 
@@ -147,7 +147,7 @@ describe('unique', () => {
   describe('arrays of objects', () => {
     test('validation passes when objects have different values', () => {
       const value = [{ id: 1 }, { id: 2 }];
-      const context: ConstraintContext = createContext('tags', value, {} as UniqueOptions);
+      const context: ConstraintContext = createContext('tags', value, {});
 
       const violations = unique(value, context);
 
@@ -156,7 +156,7 @@ describe('unique', () => {
 
     test('validation fails when objects have the same values', () => {
       const value = [{ id: 1 }, { id: 1 }];
-      const context: ConstraintContext = createContext('tags', value, {} as UniqueOptions);
+      const context: ConstraintContext = createContext('tags', value, {});
 
       const violations = unique(value, context);
 

--- a/src/validator/constraints/comparison/unique.test.ts
+++ b/src/validator/constraints/comparison/unique.test.ts
@@ -1,18 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { ConstraintContext } from '@/validator/constraint-validator';
-import { unique } from './unique';
+import { unique, UniqueOptions } from './unique';
 
 describe('unique', () => {
   it('returns no violations when array elements are unique', () => {
     const value = ['7', 7, true];
-    const context: ConstraintContext = {
-      path: 'tags',
-      root: { tags: value },
-      value,
-      constraint: 'unique',
-      options: {},
-      runNestedRules: () => [],
-    };
+    const context: ConstraintContext = createContext('tags', value, {} as UniqueOptions);
 
     const violations = unique(value, context);
 
@@ -21,14 +14,7 @@ describe('unique', () => {
 
   it('returns one violation when an array contains duplicate elements', () => {
     const value = ['admin', 'editor', 'admin'];
-    const context: ConstraintContext = {
-      path: 'tags',
-      root: { tags: value },
-      value,
-      constraint: 'unique',
-      options: {},
-      runNestedRules: () => [],
-    };
+    const context: ConstraintContext = createContext('tags', value, {} as UniqueOptions);
 
     const violations = unique(value, context);
 
@@ -41,16 +27,33 @@ describe('unique', () => {
     });
   });
 
+  it('returns one violation when the value is not an array', () => {
+    const value = 'admin';
+    const context: ConstraintContext = createContext('tags', value, {} as UniqueOptions);
+
+    const violations = unique(value, context);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toEqual({
+      path: 'tags',
+      constraint: 'unique',
+      message: 'This collection should contain only unique elements.',
+      value,
+    });
+  });
+
+  it('should bypass undefined value', () => {
+    const value = undefined;
+    const context: ConstraintContext = createContext('tags', value, { message: 'Tags must be unique' });
+
+    const violations = unique(value, context);
+
+    expect(violations).toHaveLength(0);
+  });
+
   it('uses a custom message when provided', () => {
     const value = ['admin', 'admin'];
-    const context: ConstraintContext = {
-      path: 'tags',
-      root: { tags: value },
-      value,
-      constraint: 'unique',
-      options: { message: 'Tags must be unique' },
-      runNestedRules: () => [],
-    };
+    const context: ConstraintContext = createContext('tags', value, { message: 'Tags must be unique' });
 
     const violations = unique(value, context);
 
@@ -63,56 +66,11 @@ describe('unique', () => {
     });
   });
 
-  it('should bypass undefined value', () => {
-    const value = undefined;
-    const context: ConstraintContext = {
-      path: 'tags',
-      root: {},
-      value,
-      constraint: 'unique',
-      options: { message: 'Tags must be unique' },
-      runNestedRules: () => [],
-    };
-
-    const violations = unique(value, context);
-
-    expect(violations).toHaveLength(0);
-  });
-
-  it('returns one violation when the value is not an array', () => {
-    const value = 'admin';
-    const context: ConstraintContext = {
-      path: 'tags',
-      root: { tags: value },
-      value,
-      constraint: 'unique',
-      options: {},
-      runNestedRules: () => [],
-    };
-
-    const violations = unique(value, context);
-
-    expect(violations).toHaveLength(1);
-    expect(violations[0]).toEqual({
-      path: 'tags',
-      constraint: 'unique',
-      message: 'This collection should contain only unique elements.',
-      value,
-    });
-  });
-
   it('normalizes each array element before checking uniqueness', () => {
     const value = ['    admin ', 'admin'];
-    const context: ConstraintContext = {
-      path: 'tags',
-      root: { tags: value },
-      value,
-      constraint: 'unique',
-      options: {
-        normalizer: (element: unknown) => (typeof element === 'string' ? element.trim() : element),
-      },
-      runNestedRules: () => [],
-    };
+    const context: ConstraintContext = createContext('tags', value, {
+      normalizer: (element: unknown) => (typeof element === 'string' ? element.trim() : element),
+    });
 
     const violations = unique(value, context);
 
@@ -131,17 +89,10 @@ describe('unique', () => {
         { latitude: 10, longitude: 20, label: '     first', name: 'first-location' },
         { latitude: 10, longitude: 20, label: 'first', name: 'last-location' },
       ];
-      const context: ConstraintContext = {
-        path: 'coordinates',
-        root: { coordinates: value },
-        value,
-        constraint: 'unique',
-        options: {
-          fields: ['latitude', 'longitude', 'label'],
-          normalizer: (fieldValue: unknown) => (typeof fieldValue === 'string' ? fieldValue.trim() : fieldValue),
-        },
-        runNestedRules: () => [],
-      };
+      const context: ConstraintContext = createContext('coordinates', value, {
+        fields: ['latitude', 'longitude', 'label'],
+        normalizer: (element: unknown) => (typeof element === 'string' ? element.trim() : element),
+      });
 
       const violations = unique(value, context);
 
@@ -159,16 +110,9 @@ describe('unique', () => {
         { latitude: 10, longitude: 20, label: 'first', name: 'first-location' },
         { latitude: 10, longitude: 20, label: 'first', name: 'last-location' },
       ];
-      const context: ConstraintContext = {
-        path: 'coordinates',
-        root: { coordinates: value },
-        value,
-        constraint: 'unique',
-        options: {
-          fields: ['latitude', 'longitude', 'label'],
-        },
-        runNestedRules: () => [],
-      };
+      const context: ConstraintContext = createContext('coordinates', value, {
+        fields: ['latitude', 'longitude', 'label'],
+      });
 
       const violations = unique(value, context);
 
@@ -181,4 +125,15 @@ describe('unique', () => {
       });
     });
   });
+
+  function createContext(path: string, value: unknown, options: UniqueOptions): ConstraintContext<UniqueOptions> {
+    return {
+      path,
+      root: { [path]: value },
+      value,
+      constraint: 'unique',
+      options,
+      runNestedRules: () => [],
+    };
+  }
 });

--- a/src/validator/constraints/comparison/unique.test.ts
+++ b/src/validator/constraints/comparison/unique.test.ts
@@ -18,4 +18,26 @@ describe('unique', () => {
 
     expect(violations).toHaveLength(0);
   });
+
+  it('returns one violation when an array contains duplicate elements', () => {
+    const value = ['admin', 'editor', 'admin'];
+    const context: ConstraintContext = {
+      path: 'tags',
+      root: { tags: value },
+      value,
+      constraint: 'unique',
+      options: {},
+      runNestedRules: () => [],
+    };
+
+    const violations = unique(value, context);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toEqual({
+      path: 'tags',
+      constraint: 'unique',
+      message: 'This collection should contain only unique elements.',
+      value,
+    });
+  });
 });

--- a/src/validator/constraints/comparison/unique.test.ts
+++ b/src/validator/constraints/comparison/unique.test.ts
@@ -1,111 +1,189 @@
-import { describe, expect, it } from 'vitest';
 import { ConstraintContext } from '@/validator/constraint-validator';
+import { describe, expect, test } from 'vitest';
 import { unique, UniqueOptions } from './unique';
 
 describe('unique', () => {
-  it('returns no violations when array elements are unique', () => {
-    const value = ['7', 7, true];
-    const context: ConstraintContext = createContext('tags', value, {} as UniqueOptions);
+  describe('non-array values', () => {
+    test('validation passes when the value is undefined', () => {
+      const value = undefined;
+      const context: ConstraintContext = createContext('tags', value, { message: 'Tags must be unique' });
 
-    const violations = unique(value, context);
+      const violations = unique(value, context);
 
-    expect(violations).toHaveLength(0);
-  });
-
-  it('returns one violation when an array contains duplicate elements', () => {
-    const value = ['admin', 'editor', 'admin'];
-    const context: ConstraintContext = createContext('tags', value, {} as UniqueOptions);
-
-    const violations = unique(value, context);
-
-    expect(violations).toHaveLength(1);
-    expect(violations[0]).toEqual({
-      path: 'tags',
-      constraint: 'unique',
-      message: 'This collection should contain only unique elements.',
-      value,
-    });
-  });
-
-  it('returns one violation when the value is not an array', () => {
-    const value = 'admin';
-    const context: ConstraintContext = createContext('tags', value, {} as UniqueOptions);
-
-    const violations = unique(value, context);
-
-    expect(violations).toHaveLength(1);
-    expect(violations[0]).toEqual({
-      path: 'tags',
-      constraint: 'unique',
-      message: 'This collection should contain only unique elements.',
-      value,
-    });
-  });
-
-  it('should bypass undefined value', () => {
-    const value = undefined;
-    const context: ConstraintContext = createContext('tags', value, { message: 'Tags must be unique' });
-
-    const violations = unique(value, context);
-
-    expect(violations).toHaveLength(0);
-  });
-
-  it('uses a custom message when provided', () => {
-    const value = ['admin', 'admin'];
-    const context: ConstraintContext = createContext('tags', value, { message: 'Tags must be unique' });
-
-    const violations = unique(value, context);
-
-    expect(violations).toHaveLength(1);
-    expect(violations[0]).toEqual({
-      path: 'tags',
-      constraint: 'unique',
-      message: 'Tags must be unique',
-      value,
-    });
-  });
-
-  it('normalizes each array element before checking uniqueness', () => {
-    const value = ['    admin ', 'admin'];
-    const context: ConstraintContext = createContext('tags', value, {
-      normalizer: (element: unknown) => (typeof element === 'string' ? element.trim() : element),
+      expect(violations).toHaveLength(0);
     });
 
-    const violations = unique(value, context);
-
-    expect(violations).toHaveLength(1);
-    expect(violations[0]).toEqual({
-      path: 'tags',
-      constraint: 'unique',
-      message: 'This collection should contain only unique elements.',
-      value,
-    });
-  });
-
-  describe('checks uniqueness using the configured field combination', () => {
-    it('with normalizer', () => {
-      const value = [
-        { latitude: 10, longitude: 20, label: '     first', name: 'first-location' },
-        { latitude: 10, longitude: 20, label: 'first', name: 'last-location' },
-      ];
-      const context: ConstraintContext = createContext('coordinates', value, {
-        fields: ['latitude', 'longitude', 'label'],
-        normalizer: (element: unknown) => (typeof element === 'string' ? element.trim() : element),
-      });
+    test('validation fails when the value is null', () => {
+      const value = null;
+      const context: ConstraintContext = createContext('tags', value, {} as UniqueOptions);
 
       const violations = unique(value, context);
 
       expect(violations).toHaveLength(1);
       expect(violations[0]).toEqual({
-        path: 'coordinates',
+        path: 'tags',
         constraint: 'unique',
-        message: 'This collection should contain only unique elements.',
+        message: 'This value must be a list.',
         value,
       });
     });
 
-    it('without normalizer', () => {
+    test('validation fails when the value is not an array', () => {
+      const value = 'admin';
+      const context: ConstraintContext = createContext('tags', value, {} as UniqueOptions);
+
+      const violations = unique(value, context);
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0]).toEqual({
+        path: 'tags',
+        constraint: 'unique',
+        message: 'This value must be a list.',
+        value,
+      });
+    });
+  });
+
+  describe('arrays of scalars', () => {
+    test('validation passes when array elements are unique', () => {
+      const value = ['7', 7, true, null, undefined];
+      const context: ConstraintContext = createContext('tags', value, {} as UniqueOptions);
+
+      const violations = unique(value, context);
+
+      expect(violations).toHaveLength(0);
+    });
+
+    test('validation passes when the array contains a null value', () => {
+      const value = [null];
+      const context: ConstraintContext = createContext('tags', value, {} as UniqueOptions);
+
+      const violations = unique(value, context);
+
+      expect(violations).toHaveLength(0);
+    });
+
+    test('validation passes when the array contains an undefined value', () => {
+      const value = [undefined];
+      const context: ConstraintContext = createContext('tags', value, {} as UniqueOptions);
+
+      const violations = unique(value, context);
+
+      expect(violations).toHaveLength(0);
+    });
+
+    test('validation fails when an array contains duplicate null values', () => {
+      const value = [null, null];
+      const context: ConstraintContext = createContext('tags', value, {} as UniqueOptions);
+
+      const violations = unique(value, context);
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0]).toEqual({
+        path: 'tags',
+        constraint: 'unique',
+        message: 'This value must contain only unique items.',
+        value,
+      });
+    });
+
+    test('validation fails when an array contains duplicate undefined values', () => {
+      const value = [undefined, undefined];
+      const context: ConstraintContext = createContext('tags', value, {} as UniqueOptions);
+
+      const violations = unique(value, context);
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0]).toEqual({
+        path: 'tags',
+        constraint: 'unique',
+        message: 'This value must contain only unique items.',
+        value,
+      });
+    });
+
+    test('validation fails when an array contains duplicate elements', () => {
+      const value = ['admin', 'editor', 'admin'];
+      const context: ConstraintContext = createContext('tags', value, {} as UniqueOptions);
+
+      const violations = unique(value, context);
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0]).toEqual({
+        path: 'tags',
+        constraint: 'unique',
+        message: 'This value must contain only unique items.',
+        value,
+      });
+    });
+  });
+
+  describe('arrays of arrays', () => {
+    test('validation passes when nested arrays have different values', () => {
+      const value = [['admin'], ['editor']];
+      const context: ConstraintContext = createContext('tags', value, {} as UniqueOptions);
+
+      const violations = unique(value, context);
+
+      expect(violations).toHaveLength(0);
+    });
+
+    test('validation fails when nested arrays have the same values', () => {
+      const value = [['admin'], ['admin']];
+      const context: ConstraintContext = createContext('tags', value, {} as UniqueOptions);
+
+      const violations = unique(value, context);
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0]).toEqual({
+        path: 'tags',
+        constraint: 'unique',
+        message: 'This value must contain only unique items.',
+        value,
+      });
+    });
+  });
+
+  describe('arrays of objects', () => {
+    test('validation passes when objects have different values', () => {
+      const value = [{ id: 1 }, { id: 2 }];
+      const context: ConstraintContext = createContext('tags', value, {} as UniqueOptions);
+
+      const violations = unique(value, context);
+
+      expect(violations).toHaveLength(0);
+    });
+
+    test('validation fails when objects have the same values', () => {
+      const value = [{ id: 1 }, { id: 1 }];
+      const context: ConstraintContext = createContext('tags', value, {} as UniqueOptions);
+
+      const violations = unique(value, context);
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0]).toEqual({
+        path: 'tags',
+        constraint: 'unique',
+        message: 'This value must contain only unique items.',
+        value,
+      });
+    });
+
+    test('validation passes when the configured field combinations are unique', () => {
+      const value = [
+        { latitude: 10, longitude: 20, label: 'first', name: 'first-location' },
+        { latitude: 10, longitude: 30, label: 'first', name: 'last-location' },
+      ];
+      const context: ConstraintContext = createContext('coordinates', value, {
+        fields: ['latitude', 'longitude', 'label'],
+      });
+
+      const violations = unique(value, context);
+
+      expect(violations).toHaveLength(0);
+    });
+
+    test('validation fails when the configured field combinations contain duplicates', () => {
       const value = [
         { latitude: 10, longitude: 20, label: 'first', name: 'first-location' },
         { latitude: 10, longitude: 20, label: 'first', name: 'last-location' },
@@ -120,7 +198,101 @@ describe('unique', () => {
       expect(violations[0]).toEqual({
         path: 'coordinates',
         constraint: 'unique',
-        message: 'This collection should contain only unique elements.',
+        message: 'This value must contain only unique items.',
+        value,
+      });
+    });
+
+    test('validation fails when fields are configured and an element is not an object', () => {
+      const value = [{ id: 1 }, 'admin'];
+      const context: ConstraintContext = createContext('tags', value, {
+        fields: ['id'],
+      });
+
+      const violations = unique(value, context);
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0]).toEqual({
+        path: 'tags',
+        constraint: 'unique',
+        message: 'This value must be a list of objects.',
+        value,
+      });
+    });
+  });
+
+  describe('options', () => {
+    test('validation uses a custom message when it fails', () => {
+      const value = ['admin', 'admin'];
+      const context: ConstraintContext = createContext('tags', value, { message: 'Tags must be unique' });
+
+      const violations = unique(value, context);
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0]).toEqual({
+        path: 'tags',
+        constraint: 'unique',
+        message: 'Tags must be unique',
+        value,
+      });
+    });
+
+    test('validation normalizes each array element before checking uniqueness', () => {
+      const value = ['    admin ', 'admin'];
+      const context: ConstraintContext = createContext('tags', value, {
+        normalizer: (element: unknown) => (typeof element === 'string' ? element.trim() : element),
+      });
+
+      const violations = unique(value, context);
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0]).toEqual({
+        path: 'tags',
+        constraint: 'unique',
+        message: 'This value must contain only unique items.',
+        value,
+      });
+    });
+
+    test('validation normalizes each object before checking configured field combinations', () => {
+      const value = [
+        { latitude: 10, longitude: 20, label: '     first', name: 'first-location' },
+        { latitude: 10, longitude: 20, label: 'first', name: 'last-location' },
+      ];
+      const context: ConstraintContext = createContext('coordinates', value, {
+        fields: ['latitude', 'longitude', 'label'],
+        normalizer: (element: unknown) =>
+          typeof element === 'object' && element !== null && 'label' in element
+            ? { ...element, label: String(element.label).trim() }
+            : element,
+      });
+
+      const violations = unique(value, context);
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0]).toEqual({
+        path: 'coordinates',
+        constraint: 'unique',
+        message: 'This value must contain only unique items.',
+        value,
+      });
+    });
+
+    test('validation fails when fields are configured and normalization returns a non-object element', () => {
+      const value = [{ id: 1 }, { id: 2 }];
+      const context: ConstraintContext = createContext('tags', value, {
+        fields: ['id'],
+        normalizer: (element: unknown) =>
+          typeof element === 'object' && element !== null && 'id' in element && element.id === 2 ? 'admin' : element,
+      });
+
+      const violations = unique(value, context);
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0]).toEqual({
+        path: 'tags',
+        constraint: 'unique',
+        message: 'This value must be a list of objects.',
         value,
       });
     });

--- a/src/validator/constraints/comparison/unique.test.ts
+++ b/src/validator/constraints/comparison/unique.test.ts
@@ -100,4 +100,29 @@ describe('unique', () => {
       value,
     });
   });
+
+  it('normalizes each array element before checking uniqueness', () => {
+    const value = [' admin ', 'admin'];
+    const context: ConstraintContext = {
+      path: 'tags',
+      root: { tags: value },
+      value,
+      constraint: 'unique',
+      options: {
+        normalizer: (element: unknown) => (typeof element === 'string' ? element.trim() : element),
+      },
+      runNestedRules: () => [],
+    };
+
+    const violations = unique(value, context);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toEqual({
+      path: 'tags',
+      constraint: 'unique',
+      message: 'This collection should contain only unique elements.',
+      value,
+    });
+  });
+
 });

--- a/src/validator/constraints/comparison/unique.test.ts
+++ b/src/validator/constraints/comparison/unique.test.ts
@@ -102,7 +102,7 @@ describe('unique', () => {
   });
 
   it('normalizes each array element before checking uniqueness', () => {
-    const value = [' admin ', 'admin'];
+    const value = ['    admin ', 'admin'];
     const context: ConstraintContext = {
       path: 'tags',
       root: { tags: value },
@@ -125,4 +125,31 @@ describe('unique', () => {
     });
   });
 
+  it('checks uniqueness using the configured field combination', () => {
+    const value = [
+      { latitude: 10, longitude: 20, label: '     first', name: 'first-location' },
+      { latitude: 10, longitude: 20, label: 'first', name: 'last-location' },
+    ];
+    const context: ConstraintContext = {
+      path: 'coordinates',
+      root: { coordinates: value },
+      value,
+      constraint: 'unique',
+      options: {
+        fields: ['latitude', 'longitude', 'label'],
+        normalizer: (fieldValue: unknown) => (typeof fieldValue === 'string' ? fieldValue.trim() : fieldValue),
+      },
+      runNestedRules: () => [],
+    };
+
+    const violations = unique(value, context);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toEqual({
+      path: 'coordinates',
+      constraint: 'unique',
+      message: 'This collection should contain only unique elements.',
+      value,
+    });
+  });
 });

--- a/src/validator/constraints/comparison/unique.test.ts
+++ b/src/validator/constraints/comparison/unique.test.ts
@@ -62,4 +62,20 @@ describe('unique', () => {
       value,
     });
   });
+
+  it('returns no violations when the value is undefined', () => {
+    const value = undefined;
+    const context: ConstraintContext = {
+      path: 'tags',
+      root: {},
+      value,
+      constraint: 'unique',
+      options: {},
+      runNestedRules: () => [],
+    };
+
+    const violations = unique(value, context);
+
+    expect(violations).toHaveLength(0);
+  });
 });

--- a/src/validator/constraints/comparison/unique.test.ts
+++ b/src/validator/constraints/comparison/unique.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { ConstraintContext } from '@/validator/constraint-validator';
+import { unique } from './unique';
+
+describe('unique', () => {
+  it('returns no violations when array elements are unique', () => {
+    const value = ['7', 7, true];
+    const context: ConstraintContext = {
+      path: 'tags',
+      root: { tags: value },
+      value,
+      constraint: 'unique',
+      options: {},
+      runNestedRules: () => [],
+    };
+
+    const violations = unique(value, context);
+
+    expect(violations).toHaveLength(0);
+  });
+});

--- a/src/validator/constraints/comparison/unique.test.ts
+++ b/src/validator/constraints/comparison/unique.test.ts
@@ -78,4 +78,26 @@ describe('unique', () => {
 
     expect(violations).toHaveLength(0);
   });
+
+  it('returns one violation when the value is not an array', () => {
+    const value = 'admin';
+    const context: ConstraintContext = {
+      path: 'tags',
+      root: { tags: value },
+      value,
+      constraint: 'unique',
+      options: {},
+      runNestedRules: () => [],
+    };
+
+    const violations = unique(value, context);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toEqual({
+      path: 'tags',
+      constraint: 'unique',
+      message: 'This collection should contain only unique elements.',
+      value,
+    });
+  });
 });

--- a/src/validator/constraints/comparison/unique.test.ts
+++ b/src/validator/constraints/comparison/unique.test.ts
@@ -125,31 +125,60 @@ describe('unique', () => {
     });
   });
 
-  it('checks uniqueness using the configured field combination', () => {
-    const value = [
-      { latitude: 10, longitude: 20, label: '     first', name: 'first-location' },
-      { latitude: 10, longitude: 20, label: 'first', name: 'last-location' },
-    ];
-    const context: ConstraintContext = {
-      path: 'coordinates',
-      root: { coordinates: value },
-      value,
-      constraint: 'unique',
-      options: {
-        fields: ['latitude', 'longitude', 'label'],
-        normalizer: (fieldValue: unknown) => (typeof fieldValue === 'string' ? fieldValue.trim() : fieldValue),
-      },
-      runNestedRules: () => [],
-    };
+  describe('checks uniqueness using the configured field combination', () => {
+    it('with normalizer', () => {
+      const value = [
+        { latitude: 10, longitude: 20, label: '     first', name: 'first-location' },
+        { latitude: 10, longitude: 20, label: 'first', name: 'last-location' },
+      ];
+      const context: ConstraintContext = {
+        path: 'coordinates',
+        root: { coordinates: value },
+        value,
+        constraint: 'unique',
+        options: {
+          fields: ['latitude', 'longitude', 'label'],
+          normalizer: (fieldValue: unknown) => (typeof fieldValue === 'string' ? fieldValue.trim() : fieldValue),
+        },
+        runNestedRules: () => [],
+      };
 
-    const violations = unique(value, context);
+      const violations = unique(value, context);
 
-    expect(violations).toHaveLength(1);
-    expect(violations[0]).toEqual({
-      path: 'coordinates',
-      constraint: 'unique',
-      message: 'This collection should contain only unique elements.',
-      value,
+      expect(violations).toHaveLength(1);
+      expect(violations[0]).toEqual({
+        path: 'coordinates',
+        constraint: 'unique',
+        message: 'This collection should contain only unique elements.',
+        value,
+      });
+    });
+
+    it('without normalizer', () => {
+      const value = [
+        { latitude: 10, longitude: 20, label: 'first', name: 'first-location' },
+        { latitude: 10, longitude: 20, label: 'first', name: 'last-location' },
+      ];
+      const context: ConstraintContext = {
+        path: 'coordinates',
+        root: { coordinates: value },
+        value,
+        constraint: 'unique',
+        options: {
+          fields: ['latitude', 'longitude', 'label'],
+        },
+        runNestedRules: () => [],
+      };
+
+      const violations = unique(value, context);
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0]).toEqual({
+        path: 'coordinates',
+        constraint: 'unique',
+        message: 'This collection should contain only unique elements.',
+        value,
+      });
     });
   });
 });

--- a/src/validator/constraints/comparison/unique.ts
+++ b/src/validator/constraints/comparison/unique.ts
@@ -1,5 +1,18 @@
 import { ConstraintContext } from '@/validator/constraint-validator';
 
-export function unique(_: unknown, __: ConstraintContext) {
+const DEFAULT_MESSAGE = 'This collection should contain only unique elements.';
+
+export function unique(value: unknown, context: ConstraintContext) {
+  if (Array.isArray(value) && new Set(value).size !== value.length) {
+    return [
+      {
+        path: context.path,
+        constraint: context.constraint,
+        message: DEFAULT_MESSAGE,
+        value,
+      },
+    ];
+  }
+
   return [];
 }

--- a/src/validator/constraints/comparison/unique.ts
+++ b/src/validator/constraints/comparison/unique.ts
@@ -27,18 +27,10 @@ export function unique(value: unknown, context: ConstraintContext<UniqueOptions>
 
   const normalizer = context.options.normalizer;
   const fields = context.options.fields;
+  let banana: unknown[];
+  banana = getValu(fields, normalizer, value, banana);
 
-  if (fields === undefined) {
-    const normalized = normalizer ? value.map(element => normalizer(element)) : value;
-    if (isUnique(normalized)) return [];
-  } else if (fields.length > 0) {
-    const fieldsValues = value.map(valueElement => fields.map(field => valueElement[field]));
-    const normalizedValues = normalizer
-      ? fieldsValues.map(fieldsValues => fieldsValues.map(fieldsValue => normalizer(fieldsValue)))
-      : value;
-    const serialized = normalizedValues.map(normalizedValue => JSON.stringify(normalizedValue));
-    if (isUnique(serialized)) return [];
-  }
+  if (isUnique(banana)) return [];
 
   return [
     {
@@ -48,6 +40,17 @@ export function unique(value: unknown, context: ConstraintContext<UniqueOptions>
       value,
     },
   ];
+}
+
+function getValu(fields: string[] | undefined, normalizer: ((value: unknown) => unknown) | undefined, value: unknown) {
+  if (fields !== undefined && fields.length > 0) {
+    const fieldsValues = value.map(valueElement => fields.map(field => valueElement[field]));
+    const normalizedValues = normalizer
+      ? fieldsValues.map(fieldsValues => fieldsValues.map(fieldsValue => normalizer(fieldsValue)))
+      : value;
+    return normalizedValues.map(normalizedValue => JSON.stringify(normalizedValue));
+  }
+  return normalizer ? value.map(element => normalizer(element)) : value;
 }
 
 function isUnique(value: unknown[]): boolean {

--- a/src/validator/constraints/comparison/unique.ts
+++ b/src/validator/constraints/comparison/unique.ts
@@ -1,14 +1,21 @@
+import { ConstraintOptions } from '@/validator/constraint';
 import { ConstraintContext } from '@/validator/constraint-validator';
 
 const DEFAULT_MESSAGE = 'This collection should contain only unique elements.';
 
-export function unique(value: unknown, context: ConstraintContext) {
+type UniqueOptions = ConstraintOptions & {
+  message?: string;
+};
+
+export function unique(value: unknown, context: ConstraintContext<UniqueOptions>) {
+  const message = context.options.message ?? DEFAULT_MESSAGE;
+
   if (Array.isArray(value) && new Set(value).size !== value.length) {
     return [
       {
         path: context.path,
         constraint: context.constraint,
-        message: DEFAULT_MESSAGE,
+        message,
         value,
       },
     ];

--- a/src/validator/constraints/comparison/unique.ts
+++ b/src/validator/constraints/comparison/unique.ts
@@ -1,8 +1,11 @@
 import { ConstraintOptions } from '@/validator/constraint';
 import { ConstraintContext } from '@/validator/constraint-validator';
 import { Violation } from '@/validator/violation';
+import { isDeepStrictEqual } from 'node:util';
 
-const DEFAULT_MESSAGE = 'This collection should contain only unique elements.';
+const DEFAULT_MESSAGE = 'This value must contain only unique items.';
+const NOT_ARRAY_MESSAGE = 'This value must be a list.';
+const FIELDS_REQUIRE_OBJECTS_MESSAGE = 'This value must be a list of objects.';
 
 export type UniqueOptions = ConstraintOptions<{
   message?: string;
@@ -10,45 +13,48 @@ export type UniqueOptions = ConstraintOptions<{
   fields?: string[];
 }>;
 
+const createViolation = (value: unknown, context: ConstraintContext, message: string): Violation => ({
+  path: context.path,
+  constraint: context.constraint,
+  message,
+  value,
+});
+
+const pickFields = (value: Record<string, unknown>, fields: string[]): Record<string, unknown> =>
+  Object.fromEntries(fields.map(field => [field, value[field]]));
+
+const normalizeElements = (value: unknown[], normalizer?: (value: unknown) => unknown): unknown[] =>
+  normalizer ? value.map(element => normalizer(element)) : value;
+
+const hasConfiguredFields = (fields?: string[]): fields is string[] => fields !== undefined && fields.length > 0;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const containsOnlyRecords = (values: unknown[]): values is Record<string, unknown>[] => values.every(isRecord);
+
+const prepareComparableElements = (value: unknown[], fields?: string[]): unknown[] =>
+  hasConfiguredFields(fields) ? value.map(element => pickFields(element as Record<string, unknown>, fields)) : value;
+
+const hasOnlyUniqueValues = (values: unknown[]): boolean =>
+  values.every((value, index) =>
+    values.every((candidate, candidateIndex) => candidateIndex <= index || !isDeepStrictEqual(value, candidate)),
+  );
+
 export function unique(value: unknown, context: ConstraintContext<UniqueOptions>): Violation[] {
-  if (value === undefined) {
-    return [];
-  }
-  if (!Array.isArray(value)) {
-    return [
-      {
-        path: context.path,
-        constraint: context.constraint,
-        message: context.options.message ?? DEFAULT_MESSAGE,
-        value,
-      },
-    ];
+  if (value === undefined) return [];
+
+  if (!Array.isArray(value)) return [createViolation(value, context, context.options.message ?? NOT_ARRAY_MESSAGE)];
+
+  const normalizedElements = normalizeElements(value, context.options.normalizer);
+
+  if (hasConfiguredFields(context.options.fields) && !containsOnlyRecords(normalizedElements)) {
+    return [createViolation(value, context, context.options.message ?? FIELDS_REQUIRE_OBJECTS_MESSAGE)];
   }
 
-  const fields = context.options.fields;
-  const normalizer = context.options.normalizer;
-  let normalized: unknown[];
+  const comparableElements = prepareComparableElements(normalizedElements, context.options.fields);
 
-  if (fields !== undefined && fields.length > 0) {
-    const fieldCombinations: unknown[][] = value.map(element => fields.map(field => element[field]));
-    const normalizedCombinations: unknown[][] = fieldCombinations.map(fieldCombination =>
-      fieldCombination.map(fieldValue => (normalizer ? normalizer(fieldValue) : fieldValue)),
-    );
-    normalized = normalizedCombinations.map(combination => JSON.stringify(combination));
-  } else normalized = normalizer ? value.map(element => normalizer(element)) : value;
+  if (hasOnlyUniqueValues(comparableElements)) return [];
 
-  if (isUnique(normalized)) return [];
-
-  return [
-    {
-      path: context.path,
-      constraint: context.constraint,
-      message: context.options.message ?? DEFAULT_MESSAGE,
-      value,
-    },
-  ];
-}
-
-function isUnique(value: unknown[]): boolean {
-  return new Set(value).size === value.length;
+  return [createViolation(value, context, context.options.message ?? DEFAULT_MESSAGE)];
 }

--- a/src/validator/constraints/comparison/unique.ts
+++ b/src/validator/constraints/comparison/unique.ts
@@ -25,7 +25,14 @@ export function unique(value: unknown, context: ConstraintContext<UniqueOptions>
     ];
   }
 
-  if (hasUniqueValues(value, context.options.fields, context.options.normalizer)) return [];
+  const normalizer = context.options.normalizer;
+
+  if (context.options.fields === undefined) {
+    const normalized = normalizer ? value.map(element => normalizer(element)) : value;
+    if (isUnique(serializedValues(normalized))) return [];
+  }
+
+  if (hasUniqueValues(value, context.options.fields, normalizer)) return [];
 
   return [
     {

--- a/src/validator/constraints/comparison/unique.ts
+++ b/src/validator/constraints/comparison/unique.ts
@@ -6,50 +6,79 @@ const DEFAULT_MESSAGE = 'This collection should contain only unique elements.';
 type UniqueOptions = ConstraintOptions & {
   message?: string;
   normalizer?: (value: unknown) => unknown;
+  fields?: string[];
 };
 
 export function unique(value: unknown, context: ConstraintContext<UniqueOptions>) {
-  const message = context.options.message ?? DEFAULT_MESSAGE;
+  const options = context.options;
+  const message = options.message ?? DEFAULT_MESSAGE;
+  const fields = options.fields;
+  const normalizer = options.normalizer;
 
   if (value === undefined) {
     return [];
   }
 
-  if (!Array.isArray(value)) {
-    return [
-      {
-        path: context.path,
-        constraint: context.constraint,
-        message,
-        value,
-      },
-    ];
-  }
+  if (Array.isArray(value) && hasUniqueValues(value, fields, normalizer)) return [];
 
-  const normalizedValue = normalizeElements(value, context.options.normalizer);
-
-  if (!hasUniqueElements(normalizedValue)) {
-    return [
-      {
-        path: context.path,
-        constraint: context.constraint,
-        message,
-        value,
-      },
-    ];
-  }
-
-  return [];
+  return [
+    {
+      path: context.path,
+      constraint: context.constraint,
+      message,
+      value,
+    },
+  ];
 }
 
-function normalizeElements(value: unknown[], normalizer?: (value: unknown) => unknown): unknown[] {
+function hasUniqueValues(
+  value: Record<string, unknown>[],
+  fields: string[] | undefined,
+  normalizer?: ((value: unknown) => unknown) | undefined,
+): boolean {
+  let normalizedValues: unknown[] | unknown[][];
+
+  if (Array.isArray(fields) && fields.length > 0) {
+    const fieldsValues = getFieldsValues(value, fields);
+    normalizedValues = normalizeFieldsValues(fieldsValues, normalizer);
+  } else {
+    normalizedValues = normalizeFieldsValues(value, normalizer);
+  }
+
+  return isUnique(serializedValues(normalizedValues));
+}
+
+function getFieldsValues(arrayElements: Record<string, unknown>[], fieldNames: string[]): unknown[][] {
+  return arrayElements.map(arrayElement => fieldNames.map(fieldName => getFieldValue(arrayElement, fieldName)));
+
+  function getFieldValue(arrayElement: Record<string, unknown>, fieldName: string): unknown {
+    return typeof arrayElement === 'object' && arrayElement !== null ? arrayElement[fieldName] : undefined;
+  }
+}
+
+function normalizeFieldsValues<TValue>(
+  fieldsValues: TValue[] | TValue[][],
+  normalizer?: (value: TValue) => TValue,
+): TValue[] | TValue[][] {
   if (typeof normalizer !== 'function') {
-    return value;
+    return fieldsValues;
   }
 
-  return value.map(element => normalizer(element));
+  if (fieldsValues.every(fieldValue => Array.isArray(fieldValue))) {
+    return fieldsValues.map(fieldValues => fieldValues.map(fieldValue => normalizer(fieldValue as TValue)));
+  }
+
+  return fieldsValues.map(fieldValue => normalizer(fieldValue as TValue));
 }
 
-function hasUniqueElements(value: unknown[]): boolean {
+function serializedValues(values: unknown[] | unknown[][]): unknown[] {
+  if (values.every(value => Array.isArray(value))) {
+    return values.map(value => JSON.stringify(value));
+  }
+
+  return values;
+}
+
+function isUnique(value: unknown[]): boolean {
   return new Set(value).size === value.length;
 }

--- a/src/validator/constraints/comparison/unique.ts
+++ b/src/validator/constraints/comparison/unique.ts
@@ -5,6 +5,7 @@ const DEFAULT_MESSAGE = 'This collection should contain only unique elements.';
 
 type UniqueOptions = ConstraintOptions & {
   message?: string;
+  normalizer?: (value: unknown) => unknown;
 };
 
 export function unique(value: unknown, context: ConstraintContext<UniqueOptions>) {
@@ -14,7 +15,20 @@ export function unique(value: unknown, context: ConstraintContext<UniqueOptions>
     return [];
   }
 
-  if (!Array.isArray(value) || !hasUniqueElements(value)) {
+  if (!Array.isArray(value)) {
+    return [
+      {
+        path: context.path,
+        constraint: context.constraint,
+        message,
+        value,
+      },
+    ];
+  }
+
+  const normalizedValue = normalizeElements(value, context.options.normalizer);
+
+  if (!hasUniqueElements(normalizedValue)) {
     return [
       {
         path: context.path,
@@ -26,6 +40,14 @@ export function unique(value: unknown, context: ConstraintContext<UniqueOptions>
   }
 
   return [];
+}
+
+function normalizeElements(value: unknown[], normalizer?: (value: unknown) => unknown): unknown[] {
+  if (typeof normalizer !== 'function') {
+    return value;
+  }
+
+  return value.map(element => normalizer(element));
 }
 
 function hasUniqueElements(value: unknown[]): boolean {

--- a/src/validator/constraints/comparison/unique.ts
+++ b/src/validator/constraints/comparison/unique.ts
@@ -30,11 +30,11 @@ export function unique(value: unknown, context: ConstraintContext<UniqueOptions>
   let normalized: unknown[];
 
   if (fields !== undefined && fields.length > 0) {
-    const fieldsValues = value.map(valueElement => fields.map(field => valueElement[field]));
-    const normalizedValues = normalizer
-      ? fieldsValues.map(fieldsValues => fieldsValues.map(fieldsValue => normalizer(fieldsValue)))
-      : fieldsValues;
-    normalized = normalizedValues.map(normalizedValue => JSON.stringify(normalizedValue));
+    const fieldCombinations: unknown[][] = value.map(element => fields.map(field => element[field]));
+    const normalizedCombinations: unknown[][] = fieldCombinations.map(fieldCombination =>
+      fieldCombination.map(fieldValue => (normalizer ? normalizer(fieldValue) : fieldValue)),
+    );
+    normalized = normalizedCombinations.map(combination => JSON.stringify(combination));
   } else normalized = normalizer ? value.map(element => normalizer(element)) : value;
 
   if (isUnique(normalized)) return [];

--- a/src/validator/constraints/comparison/unique.ts
+++ b/src/validator/constraints/comparison/unique.ts
@@ -25,12 +25,19 @@ export function unique(value: unknown, context: ConstraintContext<UniqueOptions>
     ];
   }
 
-  const normalizer = context.options.normalizer;
   const fields = context.options.fields;
-  let banana: unknown[];
-  banana = getValu(fields, normalizer, value, banana);
+  const normalizer = context.options.normalizer;
+  let normalized: unknown[];
 
-  if (isUnique(banana)) return [];
+  if (fields !== undefined && fields.length > 0) {
+    const fieldsValues = value.map(valueElement => fields.map(field => valueElement[field]));
+    const normalizedValues = normalizer
+      ? fieldsValues.map(fieldsValues => fieldsValues.map(fieldsValue => normalizer(fieldsValue)))
+      : value;
+    normalized = normalizedValues.map(normalizedValue => JSON.stringify(normalizedValue));
+  } else normalized = normalizer ? value.map(element => normalizer(element)) : value;
+
+  if (isUnique(normalized)) return [];
 
   return [
     {
@@ -40,17 +47,6 @@ export function unique(value: unknown, context: ConstraintContext<UniqueOptions>
       value,
     },
   ];
-}
-
-function getValu(fields: string[] | undefined, normalizer: ((value: unknown) => unknown) | undefined, value: unknown) {
-  if (fields !== undefined && fields.length > 0) {
-    const fieldsValues = value.map(valueElement => fields.map(field => valueElement[field]));
-    const normalizedValues = normalizer
-      ? fieldsValues.map(fieldsValues => fieldsValues.map(fieldsValue => normalizer(fieldsValue)))
-      : value;
-    return normalizedValues.map(normalizedValue => JSON.stringify(normalizedValue));
-  }
-  return normalizer ? value.map(element => normalizer(element)) : value;
 }
 
 function isUnique(value: unknown[]): boolean {

--- a/src/validator/constraints/comparison/unique.ts
+++ b/src/validator/constraints/comparison/unique.ts
@@ -1,15 +1,16 @@
 import { ConstraintOptions } from '@/validator/constraint';
 import { ConstraintContext } from '@/validator/constraint-validator';
+import { Violation } from '@/validator/violation';
 
 const DEFAULT_MESSAGE = 'This collection should contain only unique elements.';
 
-type UniqueOptions = ConstraintOptions & {
+export type UniqueOptions = ConstraintOptions & {
   message?: string;
   normalizer?: (value: unknown) => unknown;
   fields?: string[];
 };
 
-export function unique(value: unknown, context: ConstraintContext<UniqueOptions>) {
+export function unique(value: unknown, context: ConstraintContext<UniqueOptions>): Violation[] {
   const options = context.options;
   const message = options.message ?? DEFAULT_MESSAGE;
   const fields = options.fields;

--- a/src/validator/constraints/comparison/unique.ts
+++ b/src/validator/constraints/comparison/unique.ts
@@ -1,32 +1,27 @@
-import { ConstraintOptions } from '@/validator/constraint';
-import { ConstraintContext } from '@/validator/constraint-validator';
-import { Violation } from '@/validator/violation';
+import {ConstraintOptions} from '@/validator/constraint';
+import {ConstraintContext} from '@/validator/constraint-validator';
+import {Violation} from '@/validator/violation';
 
 const DEFAULT_MESSAGE = 'This collection should contain only unique elements.';
 
-export type UniqueOptions = ConstraintOptions & {
+export type UniqueOptions = ConstraintOptions<{
   message?: string;
   normalizer?: (value: unknown) => unknown;
   fields?: string[];
-};
+}>;
 
 export function unique(value: unknown, context: ConstraintContext<UniqueOptions>): Violation[] {
-  const options = context.options;
-  const message = options.message ?? DEFAULT_MESSAGE;
-  const fields = options.fields;
-  const normalizer = options.normalizer;
-
   if (value === undefined) {
     return [];
   }
 
-  if (Array.isArray(value) && hasUniqueValues(value, fields, normalizer)) return [];
+  if (Array.isArray(value) && hasUniqueValues(value, context.options.fields, context.options.normalizer)) return [];
 
   return [
     {
       path: context.path,
       constraint: context.constraint,
-      message,
+      message: context.options.message ?? DEFAULT_MESSAGE,
       value,
     },
   ];

--- a/src/validator/constraints/comparison/unique.ts
+++ b/src/validator/constraints/comparison/unique.ts
@@ -33,7 +33,7 @@ export function unique(value: unknown, context: ConstraintContext<UniqueOptions>
     const fieldsValues = value.map(valueElement => fields.map(field => valueElement[field]));
     const normalizedValues = normalizer
       ? fieldsValues.map(fieldsValues => fieldsValues.map(fieldsValue => normalizer(fieldsValue)))
-      : value;
+      : fieldsValues;
     normalized = normalizedValues.map(normalizedValue => JSON.stringify(normalizedValue));
   } else normalized = normalizer ? value.map(element => normalizer(element)) : value;
 

--- a/src/validator/constraints/comparison/unique.ts
+++ b/src/validator/constraints/comparison/unique.ts
@@ -1,0 +1,5 @@
+import { ConstraintContext } from '@/validator/constraint-validator';
+
+export function unique(_: unknown, __: ConstraintContext) {
+  return [];
+}

--- a/src/validator/constraints/comparison/unique.ts
+++ b/src/validator/constraints/comparison/unique.ts
@@ -26,13 +26,21 @@ export function unique(value: unknown, context: ConstraintContext<UniqueOptions>
   }
 
   const normalizer = context.options.normalizer;
+  const fields = context.options.fields;
 
-  if (context.options.fields === undefined) {
+  if (fields === undefined) {
     const normalized = normalizer ? value.map(element => normalizer(element)) : value;
-    if (isUnique(serializedValues(normalized))) return [];
+    if (isUnique(normalized)) return [];
   }
 
-  if (hasUniqueValues(value, context.options.fields, normalizer)) return [];
+  if (fields !== undefined && fields.length > 0) {
+    const fieldsValues = value.map(valueElement => fields.map(field => valueElement[field]));
+    const normalizedValues = normalizer
+      ? fieldsValues.map(fieldsValues => fieldsValues.map(fieldsValue => normalizer(fieldsValue)))
+      : value;
+    const serialized = normalizedValues.map(normalizedValue => JSON.stringify(normalizedValue));
+    if (isUnique(serialized)) return [];
+  }
 
   return [
     {
@@ -42,54 +50,6 @@ export function unique(value: unknown, context: ConstraintContext<UniqueOptions>
       value,
     },
   ];
-}
-
-function hasUniqueValues(
-  value: Record<string, unknown>[] | unknown[],
-  fields: string[] | undefined,
-  normalizer?: ((value: unknown) => unknown) | undefined,
-): boolean {
-  let normalizedValues: unknown[] | unknown[][];
-
-  if (Array.isArray(fields) && fields.length > 0) {
-    const fieldsValues = getFieldsValues(value, fields);
-    normalizedValues = normalizeFieldsValues(fieldsValues, normalizer);
-  } else {
-    normalizedValues = normalizeFieldsValues(value, normalizer);
-  }
-
-  return isUnique(serializedValues(normalizedValues));
-}
-
-function getFieldsValues(arrayElements: Record<string, unknown>[], fieldNames: string[]): unknown[][] {
-  return arrayElements.map(arrayElement => fieldNames.map(fieldName => getFieldValue(arrayElement, fieldName)));
-
-  function getFieldValue(arrayElement: Record<string, unknown>, fieldName: string): unknown {
-    return typeof arrayElement === 'object' && arrayElement !== null ? arrayElement[fieldName] : undefined;
-  }
-}
-
-function normalizeFieldsValues<TValue>(
-  fieldsValues: TValue[] | TValue[][],
-  normalizer?: (value: TValue) => TValue,
-): TValue[] | TValue[][] {
-  if (typeof normalizer !== 'function') {
-    return fieldsValues;
-  }
-
-  if (fieldsValues.every(fieldValue => Array.isArray(fieldValue))) {
-    return fieldsValues.map(fieldValues => fieldValues.map(fieldValue => normalizer(fieldValue as TValue)));
-  }
-
-  return fieldsValues.map(fieldValue => normalizer(fieldValue as TValue));
-}
-
-function serializedValues(values: unknown[] | unknown[][]): unknown[] {
-  if (values.every(value => Array.isArray(value))) {
-    return values.map(value => JSON.stringify(value));
-  }
-
-  return values;
 }
 
 function isUnique(value: unknown[]): boolean {

--- a/src/validator/constraints/comparison/unique.ts
+++ b/src/validator/constraints/comparison/unique.ts
@@ -1,6 +1,6 @@
-import {ConstraintOptions} from '@/validator/constraint';
-import {ConstraintContext} from '@/validator/constraint-validator';
-import {Violation} from '@/validator/violation';
+import { ConstraintOptions } from '@/validator/constraint';
+import { ConstraintContext } from '@/validator/constraint-validator';
+import { Violation } from '@/validator/violation';
 
 const DEFAULT_MESSAGE = 'This collection should contain only unique elements.';
 
@@ -14,8 +14,18 @@ export function unique(value: unknown, context: ConstraintContext<UniqueOptions>
   if (value === undefined) {
     return [];
   }
+  if (!Array.isArray(value)) {
+    return [
+      {
+        path: context.path,
+        constraint: context.constraint,
+        message: context.options.message ?? DEFAULT_MESSAGE,
+        value,
+      },
+    ];
+  }
 
-  if (Array.isArray(value) && hasUniqueValues(value, context.options.fields, context.options.normalizer)) return [];
+  if (hasUniqueValues(value, context.options.fields, context.options.normalizer)) return [];
 
   return [
     {
@@ -28,7 +38,7 @@ export function unique(value: unknown, context: ConstraintContext<UniqueOptions>
 }
 
 function hasUniqueValues(
-  value: Record<string, unknown>[],
+  value: Record<string, unknown>[] | unknown[],
   fields: string[] | undefined,
   normalizer?: ((value: unknown) => unknown) | undefined,
 ): boolean {

--- a/src/validator/constraints/comparison/unique.ts
+++ b/src/validator/constraints/comparison/unique.ts
@@ -31,9 +31,7 @@ export function unique(value: unknown, context: ConstraintContext<UniqueOptions>
   if (fields === undefined) {
     const normalized = normalizer ? value.map(element => normalizer(element)) : value;
     if (isUnique(normalized)) return [];
-  }
-
-  if (fields !== undefined && fields.length > 0) {
+  } else if (fields.length > 0) {
     const fieldsValues = value.map(valueElement => fields.map(field => valueElement[field]));
     const normalizedValues = normalizer
       ? fieldsValues.map(fieldsValues => fieldsValues.map(fieldsValue => normalizer(fieldsValue)))

--- a/src/validator/constraints/comparison/unique.ts
+++ b/src/validator/constraints/comparison/unique.ts
@@ -10,7 +10,11 @@ type UniqueOptions = ConstraintOptions & {
 export function unique(value: unknown, context: ConstraintContext<UniqueOptions>) {
   const message = context.options.message ?? DEFAULT_MESSAGE;
 
-  if (Array.isArray(value) && new Set(value).size !== value.length) {
+  if (value === undefined) {
+    return [];
+  }
+
+  if (!Array.isArray(value) || !hasUniqueElements(value)) {
     return [
       {
         path: context.path,
@@ -22,4 +26,8 @@ export function unique(value: unknown, context: ConstraintContext<UniqueOptions>
   }
 
   return [];
+}
+
+function hasUniqueElements(value: unknown[]): boolean {
+  return new Set(value).size === value.length;
 }

--- a/src/validator/constraints/index.ts
+++ b/src/validator/constraints/index.ts
@@ -20,6 +20,7 @@ export const builtInConstraints = {
 export * from './string/email';
 export * from './string/slug';
 export * from './basic/not-blank';
+export { unique, type UniqueOptions } from './comparison/unique';
 export * from './basic/type';
 export { unique, type UniqueOptions } from './comparison/unique';
 export * from './basic/type';

--- a/src/validator/constraints/index.ts
+++ b/src/validator/constraints/index.ts
@@ -20,7 +20,6 @@ export const builtInConstraints = {
 export * from './string/email';
 export * from './string/slug';
 export * from './basic/not-blank';
-export { unique, type UniqueOptions } from './comparison/unique';
 export * from './basic/type';
 export { unique, type UniqueOptions } from './comparison/unique';
 export * from './basic/type';

--- a/src/validator/constraints/index.ts
+++ b/src/validator/constraints/index.ts
@@ -20,6 +20,7 @@ export const builtInConstraints = {
 export * from './string/email';
 export * from './string/slug';
 export * from './basic/not-blank';
+export * from './basic/type';
 export { unique, type UniqueOptions } from './comparison/unique';
 export * from './basic/type';
 export * from './other/compound';

--- a/src/validator/constraints/index.ts
+++ b/src/validator/constraints/index.ts
@@ -1,4 +1,5 @@
 import { notBlank } from '@/validator/constraints/basic/not-blank';
+import { unique } from '@/validator/constraints/comparison/unique';
 import { email } from '@/validator/constraints/string/email';
 import { slug } from '@/validator/constraints/string/slug';
 import { type } from '@/validator/constraints/basic/type';
@@ -8,6 +9,9 @@ export const builtInConstraints = {
   notBlank,
   type,
 
+  // Comparison
+  unique,
+
   // String
   email,
   slug,
@@ -16,5 +20,6 @@ export const builtInConstraints = {
 export * from './string/email';
 export * from './string/slug';
 export * from './basic/not-blank';
+export { unique, type UniqueOptions } from './comparison/unique';
 export * from './basic/type';
 export * from './other/compound';

--- a/src/validator/constraints/index.ts
+++ b/src/validator/constraints/index.ts
@@ -1,8 +1,8 @@
 import { notBlank } from '@/validator/constraints/basic/not-blank';
+import { type } from '@/validator/constraints/basic/type';
 import { unique } from '@/validator/constraints/comparison/unique';
 import { email } from '@/validator/constraints/string/email';
 import { slug } from '@/validator/constraints/string/slug';
-import { type } from '@/validator/constraints/basic/type';
 
 export const builtInConstraints = {
   // Basic
@@ -22,5 +22,4 @@ export * from './string/slug';
 export * from './basic/not-blank';
 export * from './basic/type';
 export { unique, type UniqueOptions } from './comparison/unique';
-export * from './basic/type';
 export * from './other/compound';

--- a/src/validator/factory/create-validator.test.ts
+++ b/src/validator/factory/create-validator.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from 'vitest';
-import { builtInConstraints } from '@/validator/constraints';
 import { UnknownConstraintError } from '@/validator/errors';
 import { createValidator } from '@/validator/factory/create-validator';
 import { Violation } from '@/validator/violation';
@@ -167,24 +166,6 @@ describe('Validator', () => {
         constraint: 'minLengthConstraint',
         message: 'Must be at least 3 characters',
         value: 'ab',
-      });
-    });
-
-    it('should validate duplicate array elements through the built-in constraints registry', () => {
-      const validate = createValidator({ constraints: builtInConstraints });
-      const payload = { tags: ['admin', 'editor', 'admin'] };
-      const rules = {
-        tags: [{ unique: {} }],
-      };
-
-      const violations = validate(payload, rules);
-
-      expect(violations).toHaveLength(1);
-      expect(violations[0]).toEqual({
-        path: 'tags',
-        constraint: 'unique',
-        message: 'This collection should contain only unique elements.',
-        value: payload.tags,
       });
     });
   });

--- a/src/validator/factory/create-validator.test.ts
+++ b/src/validator/factory/create-validator.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { builtInConstraints } from '@/validator/constraints';
 import { UnknownConstraintError } from '@/validator/errors';
 import { createValidator } from '@/validator/factory/create-validator';
 import { Violation } from '@/validator/violation';
@@ -166,6 +167,24 @@ describe('Validator', () => {
         constraint: 'minLengthConstraint',
         message: 'Must be at least 3 characters',
         value: 'ab',
+      });
+    });
+
+    it('should validate duplicate array elements through the built-in constraints registry', () => {
+      const validate = createValidator({ constraints: builtInConstraints });
+      const payload = { tags: ['admin', 'editor', 'admin'] };
+      const rules = {
+        tags: [{ unique: {} }],
+      };
+
+      const violations = validate(payload, rules);
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0]).toEqual({
+        path: 'tags',
+        constraint: 'unique',
+        message: 'This collection should contain only unique elements.',
+        value: payload.tags,
       });
     });
   });


### PR DESCRIPTION
### Overview

In this PR, I have introduced a new validation constraint called `unique`.

```ts
export type UniqueOptions = ConstraintOptions<{
  message?: string;
  normalizer?: (value: unknown) => unknown;
  fields?: string[];
}>;
```
It's exposed through the builtInConstraints and can be used like

```ts 
const rules = {
  tags: [{ unique: {} }],
  emails: [{ unique: { normalizer: value => typeof value === 'string' ? value.trim() : value } }],
  coordinates: [{ unique: { fields: ['latitude', 'longitude'] } }],
  usernames: [{ unique: { groups: ['create'] } }],
};
```

* Main purpose of this constraint is to validate whether the given collection contains only unique elements.
*  By default, uniqueness is checked with strict comparison semantics.
*  The constraint supports a normalizer to transform values before uniqueness is checked.
*  The constraint also supports fields to validate uniqueness based on a selected combination of object fields.
*  This constraint preserves the current optional-field behavior, which means if the value is undefined the constraint will return no violations.


### Changes made:
1. Added the unique constraint under comparison constraints.
2. Covered the required cases in unique.test file.
3. Exposed the unique constraint through the builtInConstraints object.




| Q       | A                      |
| ------- | ---------------------- |
| License | GPLv3                  |
| Issue   | Closes #170  > |

