### PR TITLE
feat(validator): add `all` constrait validator

### DIFF
--- a/src/validator/constraints/index.ts
+++ b/src/validator/constraints/index.ts
@@ -1,6 +1,7 @@
 import { notBlank } from '@/validator/constraints/basic/not-blank';
 import { type } from '@/validator/constraints/basic/type';
 import { unique } from '@/validator/constraints/comparison/unique';
+import { all } from '@/validator/constraints/other/all';
 import { email } from '@/validator/constraints/string/email';
 import { slug } from '@/validator/constraints/string/slug';
 
@@ -12,14 +13,29 @@ export const builtInConstraints = {
   // Comparison
   unique,
 
+  // Other
+  all,
+
   // String
   email,
   slug,
 };
 
-export * from './string/email';
-export * from './string/slug';
-export * from './basic/not-blank';
-export * from './basic/type';
+// ## Basic ##
+export { notBlank } from './basic/not-blank';
+export { type, type TypeOptions } from './basic/type';
+// ## Basic ##
+
+// ## Comparison ##
 export { unique, type UniqueOptions } from './comparison/unique';
-export * from './other/compound';
+// ## Comparison ##
+
+// ## String ##
+export { email } from './string/email';
+export { slug } from './string/slug';
+// ## String
+
+// ## Other ##
+export { all, type AllOptions } from './other/all';
+export { compound } from './other/compound';
+// ## Other ##

--- a/src/validator/constraints/index.ts
+++ b/src/validator/constraints/index.ts
@@ -33,7 +33,7 @@ export { unique, type UniqueOptions } from './comparison/unique';
 // ## String ##
 export { email } from './string/email';
 export { slug } from './string/slug';
-// ## String
+// ## String ##
 
 // ## Other ##
 export { all, type AllOptions } from './other/all';

--- a/src/validator/constraints/other/all.integration.test.ts
+++ b/src/validator/constraints/other/all.integration.test.ts
@@ -111,6 +111,21 @@ describe('all (integration)', () => {
         value: null,
       });
     });
+
+    test('validation appends indexed paths to bracketed field paths', () => {
+      const validate = createValidator({ constraints: { all, email } });
+      const rules = { 'user[emails]': [{ all: { constraints: ['email'] } }] };
+
+      const violations = validate({ 'user[emails]': ['invalid'] }, rules);
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0]).toEqual({
+        path: 'user[emails][0]',
+        constraint: 'email',
+        message: 'This value is not a valid email address.',
+        value: 'invalid',
+      });
+    });
   });
 
   describe('groups', () => {

--- a/src/validator/constraints/other/all.integration.test.ts
+++ b/src/validator/constraints/other/all.integration.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from 'vitest';
+import { createValidator } from '@/validator/factory/create-validator';
+import { notBlank } from '@/validator/constraints/basic/not-blank';
+import { email } from '@/validator/constraints/string/email';
+import { slug } from '@/validator/constraints/string/slug';
+import { all } from './all';
+
+describe('all (integration)', () => {
+  describe('schema integration', () => {
+    test('validation passes when the value is undefined', () => {
+      const validate = createValidator({ constraints: { all, notBlank } });
+      const rules = { tags: [{ all: { constraints: ['notBlank'] } }] };
+
+      const violations = validate({}, rules);
+
+      expect(violations).toHaveLength(0);
+    });
+
+    test('validation fails when the value is null', () => {
+      const validate = createValidator({ constraints: { all, notBlank } });
+      const rules = { tags: [{ all: { constraints: ['notBlank'] } }] };
+
+      const violations = validate({ tags: null }, rules);
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0]).toEqual({
+        path: 'tags',
+        constraint: 'all',
+        message: 'This value must be a list.',
+        value: null,
+      });
+    });
+
+    test('validation fails when the value is not an array', () => {
+      const validate = createValidator({ constraints: { all, notBlank } });
+      const rules = { tags: [{ all: { constraints: ['notBlank'] } }] };
+
+      const violations = validate({ tags: 'admin' }, rules);
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0]).toEqual({
+        path: 'tags',
+        constraint: 'all',
+        message: 'This value must be a list.',
+        value: 'admin',
+      });
+    });
+
+    test('validation passes when all array elements satisfy nested constraints', () => {
+      const validate = createValidator({ constraints: { all, notBlank } });
+      const rules = { tags: [{ all: { constraints: ['notBlank'] } }] };
+
+      const violations = validate({ tags: ['admin', 'editor'] }, rules);
+
+      expect(violations).toHaveLength(0);
+    });
+
+    test('validation returns aggregated nested violations with indexed paths', () => {
+      const validate = createValidator({ constraints: { all, notBlank, email } });
+      const rules = { emails: [{ all: { constraints: ['notBlank', 'email'] } }] };
+
+      const violations = validate({ emails: ['', 'invalid'] }, rules);
+
+      expect(violations).toHaveLength(3);
+      expect(violations[0]).toEqual({
+        path: 'emails[0]',
+        constraint: 'notBlank',
+        message: 'This value should not be blank.',
+        value: '',
+      });
+      expect(violations[1]).toEqual({
+        path: 'emails[0]',
+        constraint: 'email',
+        message: 'This value is not a valid email address.',
+        value: '',
+      });
+      expect(violations[2]).toEqual({
+        path: 'emails[1]',
+        constraint: 'email',
+        message: 'This value is not a valid email address.',
+        value: 'invalid',
+      });
+    });
+
+    test('validation accepts nested object rule definitions with options', () => {
+      const validate = createValidator({ constraints: { all, slug } });
+      const rules = { slugs: [{ all: { constraints: [{ slug: { message: 'Invalid slug' } }] } }] };
+
+      const violations = validate({ slugs: ['valid-slug', 'Invalid Slug'] }, rules);
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0]).toEqual({
+        path: 'slugs[1]',
+        constraint: 'slug',
+        message: 'Invalid slug',
+        value: 'Invalid Slug',
+      });
+    });
+
+    test('validation preserves null array elements for nested constraints', () => {
+      const validate = createValidator({ constraints: { all, email } });
+      const rules = { emails: [{ all: { constraints: ['email'] } }] };
+
+      const violations = validate({ emails: [null] }, rules);
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0]).toEqual({
+        path: 'emails[0]',
+        constraint: 'email',
+        message: 'This value is not a valid email address.',
+        value: null,
+      });
+    });
+  });
+
+  describe('groups', () => {
+    test('validation skips all when groups do not intersect', () => {
+      const validate = createValidator({ constraints: { all, notBlank } });
+      const rules = { tags: [{ all: { constraints: ['notBlank'], groups: ['create'] } }] };
+
+      const violations = validate({ tags: [''] }, rules, { groups: ['update'] });
+
+      expect(violations).toHaveLength(0);
+    });
+
+    test('validation applies nested constraint groups to array elements', () => {
+      const validate = createValidator({ constraints: { all, notBlank } });
+      const rules = { tags: [{ all: { constraints: [{ notBlank: { groups: ['create'] } }] } }] };
+
+      const violations = validate({ tags: [''] }, rules, { groups: ['update'] });
+
+      expect(violations).toHaveLength(0);
+    });
+  });
+
+  describe('composition', () => {
+    test('validation composes another all constraint with indexed paths', () => {
+      const validate = createValidator({ constraints: { all, email } });
+      const rules = { matrix: [{ all: { constraints: [{ all: { constraints: ['email'] } }] } }] };
+
+      const violations = validate({ matrix: [['valid@example.com'], ['invalid']] }, rules);
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0]).toEqual({
+        path: 'matrix[1][0]',
+        constraint: 'email',
+        message: 'This value is not a valid email address.',
+        value: 'invalid',
+      });
+    });
+  });
+});

--- a/src/validator/constraints/other/all.test.ts
+++ b/src/validator/constraints/other/all.test.ts
@@ -1,0 +1,119 @@
+import { ConstraintContext } from '@/validator/constraint-validator';
+import { Violation } from '@/validator/violation';
+import { describe, expect, test, vi } from 'vitest';
+import { all, AllOptions } from './all';
+
+describe('all', () => {
+  describe('non-array values', () => {
+    test('validation passes when the value is undefined', () => {
+      const value = undefined;
+      const context = createContext('tags', value, { constraints: ['notBlank'] });
+
+      const violations = all(value, context);
+
+      expect(violations).toHaveLength(0);
+    });
+
+    test('validation fails when the value is null', () => {
+      const value = null;
+      const context = createContext('tags', value, { constraints: ['notBlank'] });
+
+      const violations = all(value, context);
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0]).toEqual({
+        path: 'tags',
+        constraint: 'all',
+        message: 'This value must be a list.',
+        value,
+      });
+    });
+
+    test('validation fails when the value is not an array', () => {
+      const value = 'admin';
+      const context = createContext('tags', value, { constraints: ['notBlank'] });
+
+      const violations = all(value, context);
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0]).toEqual({
+        path: 'tags',
+        constraint: 'all',
+        message: 'This value must be a list.',
+        value,
+      });
+    });
+  });
+
+  describe('array elements', () => {
+    test('validation passes when every element passes nested constraints', () => {
+      const value = ['admin', 'editor'];
+      const context = createContext('tags', value, { constraints: ['notBlank'] });
+
+      const violations = all(value, context);
+
+      expect(violations).toHaveLength(0);
+      expect(context.runNestedRules).toHaveBeenCalledWith('admin', ['notBlank'], 'tags[0]');
+      expect(context.runNestedRules).toHaveBeenCalledWith('editor', ['notBlank'], 'tags[1]');
+    });
+
+    test('validation returns nested violations with indexed paths', () => {
+      const value = ['', 'admin'];
+      const context = createContext('tags', value, { constraints: ['notBlank'] });
+      const violation = {
+        path: 'tags[0]',
+        constraint: 'notBlank',
+        message: 'This value should not be blank.',
+        value: '',
+      };
+      vi.mocked(context.runNestedRules).mockImplementation(element => (element === '' ? [violation] : []));
+
+      const violations = all(value, context);
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0]).toEqual(violation);
+    });
+  });
+
+  describe('nested rules', () => {
+    test('validation applies nested constraints from arrays', () => {
+      const value = ['admin'];
+      const context = createContext('tags', value, { constraints: ['notBlank'] });
+
+      const violations = all(value, context);
+
+      expect(context.runNestedRules).toHaveBeenCalledWith('admin', ['notBlank'], 'tags[0]');
+      expect(violations).toHaveLength(0);
+    });
+
+    test('validation applies nested constraints from objects', () => {
+      const value = ['Invalid Slug'];
+      const context = createContext('slugs', value, { constraints: [{ slug: { message: 'Invalid slug' } }] });
+
+      const violations = all(value, context);
+
+      expect(context.runNestedRules).toHaveBeenCalledWith(
+        'Invalid Slug',
+        [{ slug: { message: 'Invalid slug' } }],
+        'slugs[0]',
+      );
+      expect(violations).toHaveLength(0);
+    });
+  });
+
+  function createContext(
+    path: string,
+    value: unknown,
+    options: AllOptions,
+    violations: Violation[] = [],
+  ): ConstraintContext<AllOptions> {
+    return {
+      path,
+      root: { [path]: value },
+      value,
+      constraint: 'all',
+      options,
+      runNestedRules: vi.fn(() => violations),
+    };
+  }
+});

--- a/src/validator/constraints/other/all.ts
+++ b/src/validator/constraints/other/all.ts
@@ -1,0 +1,29 @@
+import { ConstraintOptions } from '@/validator/constraint';
+import { ConstraintContext } from '@/validator/constraint-validator';
+import { FieldSchema } from '@/validator/schema';
+import { Violation } from '@/validator/violation';
+
+const NOT_ARRAY_MESSAGE = 'This value must be a list.';
+
+export type AllOptions = ConstraintOptions<{
+  constraints: FieldSchema;
+}>;
+
+const createViolation = (value: unknown, context: ConstraintContext<AllOptions>): Violation => ({
+  path: context.path,
+  constraint: context.constraint,
+  message: NOT_ARRAY_MESSAGE,
+  value,
+});
+
+const createElementPath = (path: string, index: number): string => `${path}[${index}]`;
+
+export function all(value: unknown, context: ConstraintContext<AllOptions>): Violation[] {
+  if (value === undefined) return [];
+
+  if (!Array.isArray(value)) return [createViolation(value, context)];
+
+  return value.flatMap((element, index) =>
+    context.runNestedRules(element, context.options.constraints, createElementPath(context.path, index)),
+  );
+}

--- a/src/validator/factory/create-validator.ts
+++ b/src/validator/factory/create-validator.ts
@@ -6,8 +6,12 @@ import { ConstraintContext, ConstraintValidator } from '@/validator/constraint-v
 import { Payload } from '@/validator/payload';
 
 type FieldSchemaEntry = [string, FieldSchema];
-type ConstraintsMap = Record<string, ConstraintValidator>;
+type RegisteredConstraintValidator = {
+  validate(value: unknown, context: ConstraintContext): ReturnType<ConstraintValidator>;
+}['validate'];
+type ConstraintsMap = Record<string, RegisteredConstraintValidator>;
 type ValidatorOptions = { constraints: ConstraintsMap };
+type CurrentValue = { value: unknown };
 
 export const createValidator = (options: ValidatorOptions): Validator => {
   const { constraints } = options;
@@ -30,7 +34,7 @@ function applyFieldSchema(
   payload: Payload,
   [field, schemaForField]: FieldSchemaEntry,
   activeGroups: string[],
-  currentValue?: unknown,
+  currentValue?: CurrentValue,
 ): ReturnType<ConstraintValidator> {
   const isGroupActive = (groups: string[]) => groups.length === 0 || groups.some(group => activeGroups.includes(group));
 
@@ -43,11 +47,11 @@ function applyFieldSchema(
 
     // Helper function to apply nested rules.
     const applyNestedRules = (nextValue: unknown, schema: FieldSchema, path: string) =>
-      applyFieldSchema(constraintsByName, payload, [path, schema], activeGroups, nextValue);
+      applyFieldSchema(constraintsByName, payload, [path, schema], activeGroups, { value: nextValue });
 
     // Find the constraint, build the context, and apply it.
     const constraintValidator = resolveConstraint(constraintsByName, field, constraintName);
-    const value = currentValue ?? payload[field];
+    const value = currentValue === undefined ? payload[field] : currentValue.value;
     const context: ConstraintContext = {
       path: field,
       root: payload,
@@ -65,7 +69,7 @@ function resolveConstraint(
   constraintValidatorMap: ConstraintsMap,
   field: string,
   constraintName: string,
-): ConstraintValidator {
+): RegisteredConstraintValidator {
   const constraintValidator = constraintValidatorMap[constraintName];
 
   if (!constraintValidator) {

--- a/src/validator/flatten-violations.test.ts
+++ b/src/validator/flatten-violations.test.ts
@@ -25,4 +25,78 @@ describe('Flatten violations', () => {
       username: ['The username is required.', 'The username must be unique.'],
     });
   });
+
+  test('it should format indexed violation paths', () => {
+    const violations: Violation[] = [
+      {
+        path: 'emails[0]',
+        message: 'This value is not a valid email address.',
+        constraint: 'email',
+        value: 'invalid',
+      },
+    ];
+
+    const actual = flattenViolations(violations);
+
+    expect(actual).toEqual({
+      'emails.0': ['This value is not a valid email address.'],
+    });
+  });
+
+  test('it should group multiple violations for the same formatted indexed path', () => {
+    const violations: Violation[] = [
+      {
+        path: 'emails[0]',
+        message: 'This value should not be blank.',
+        constraint: 'notBlank',
+        value: '',
+      },
+      {
+        path: 'emails[0]',
+        message: 'This value is not a valid email address.',
+        constraint: 'email',
+        value: '',
+      },
+    ];
+
+    const actual = flattenViolations(violations);
+
+    expect(actual).toEqual({
+      'emails.0': ['This value should not be blank.', 'This value is not a valid email address.'],
+    });
+  });
+
+  test('it should format deeply indexed violation paths', () => {
+    const violations: Violation[] = [
+      {
+        path: 'matrix[1][0]',
+        message: 'This value is not a valid email address.',
+        constraint: 'email',
+        value: 'invalid',
+      },
+    ];
+
+    const actual = flattenViolations(violations);
+
+    expect(actual).toEqual({
+      'matrix.1.0': ['This value is not a valid email address.'],
+    });
+  });
+
+  test('it should format named bracket paths', () => {
+    const violations: Violation[] = [
+      {
+        path: 'user[emails][0]',
+        message: 'This value is not a valid email address.',
+        constraint: 'email',
+        value: 'invalid',
+      },
+    ];
+
+    const actual = flattenViolations(violations);
+
+    expect(actual).toEqual({
+      'user.emails.0': ['This value is not a valid email address.'],
+    });
+  });
 });

--- a/src/validator/flatten-violations.ts
+++ b/src/validator/flatten-violations.ts
@@ -1,11 +1,18 @@
 import { Violation } from '@/validator/violation';
 
 export function flattenViolations(violations: Violation[]): Record<string, string[]> {
-  const groupedViolations = Object.groupBy(violations, violation => violation.path) as Record<string, Violation[]>;
+  const groupedViolations = Object.groupBy(violations, violation => formatPath(violation.path)) as Record<
+    string,
+    Violation[]
+  >;
 
   const violationEntries: Iterable<readonly [PropertyKey, string[]]> = Object.entries(groupedViolations).map(
     ([field, violations]) => [field, violations.map(v => v.message)],
   );
 
   return Object.fromEntries(violationEntries);
+}
+
+function formatPath(path: string): string {
+  return path.replaceAll('[', '.').replaceAll(']', '');
 }


### PR DESCRIPTION
| Q       | A                      |
| ------- | ---------------------- |
| License | GPLv3                  |
| Issue   | Closes #171 |

This PR:
- Adds `all` constraint.
- Extends the `flatten-violation` helper to support nested violation flattening and formating.