### PR TITLE
fix(routing): preserve typed http scope request generics

### DIFF
--- a/src/config/koala-config.ts
+++ b/src/config/koala-config.ts
@@ -3,6 +3,8 @@ import { type StaticFilesOptions } from '@/Http/Files';
 import { type EventSubscriber } from '@/Kernel';
 import type { RouteSource } from '@/routing';
 import type { DotenvConfigOptions } from 'dotenv';
+import type { HttpRequest } from '@/Http';
+import type { Request } from 'koa';
 
 /**
  * @deprecated Use function-first routes from `@koala-ts/framework/routing` with `KoalaConfig.routes` instead.
@@ -11,7 +13,7 @@ export type Controller = new (...args: unknown[]) => unknown;
 
 export type KoalaDotenvOptions = Pick<DotenvConfigOptions, 'debug' | 'encoding' | 'override' | 'quiet'>;
 
-export interface KoalaConfig {
+export interface KoalaConfig<TRequest extends Request = HttpRequest> {
   /**
    * @deprecated Use `routes` with `Route` from `@koala-ts/framework/routing` instead.
    */
@@ -19,7 +21,7 @@ export interface KoalaConfig {
   environment?: {
     dotenv?: KoalaDotenvOptions;
   };
-  routes?: RouteSource[];
+  routes?: RouteSource<TRequest>[];
   globalMiddleware?: HttpMiddleware[];
   staticFiles?: StaticFilesOptions;
   eventSubscribers?: Record<string, EventSubscriber | EventSubscriber[]>;

--- a/src/routing/definition/create-route-definition.ts
+++ b/src/routing/definition/create-route-definition.ts
@@ -1,27 +1,28 @@
-import type { HttpMiddleware } from '@/Http';
+import type { HttpMiddleware, HttpRequest } from '@/Http';
 import type { HttpMethod } from '@/routing/http-method';
 import type { RouteOptions } from '@/routing/route-options';
 import { resolveRouteOptions } from '@/routing/definition/resolve-route-options';
 import type { RouterMethod } from '@/routing/router-method';
 import type { RouteDefinition } from './route-definition';
+import type { Request } from 'koa';
 
-interface RouteDefinitionInput {
+interface RouteDefinitionInput<TRequest extends Request = HttpRequest> {
   name?: string;
   method: HttpMethod | HttpMethod[];
   path: string;
-  handler: HttpMiddleware;
-  middleware?: HttpMiddleware[];
+  handler: HttpMiddleware<TRequest>;
+  middleware?: HttpMiddleware<TRequest>[];
   options?: RouteOptions;
 }
 
-export function createRouteDefinition({
+export function createRouteDefinition<TRequest extends Request = HttpRequest>({
   name,
   method,
   path,
   handler,
   middleware = [],
   options = {},
-}: RouteDefinitionInput): RouteDefinition {
+}: RouteDefinitionInput<TRequest>): RouteDefinition<TRequest> {
   const routeOptions = resolveRouteOptions(options);
 
   return {

--- a/src/routing/definition/route-definition.ts
+++ b/src/routing/definition/route-definition.ts
@@ -1,18 +1,15 @@
-import type { HttpRequest, HttpScope, NextMiddleware } from '@/Http';
+import type { HttpRequest } from '@/Http';
 import type { RouterMethod } from '@/routing/router-method';
 import type { Request } from 'koa';
 import type { KoaBodyMiddlewareOptions } from 'koa-body';
-
-type RouteDefinitionMiddleware<TRequest extends Request = HttpRequest> = {
-  handle(scope: HttpScope<TRequest>, next: NextMiddleware): Promise<unknown>;
-}['handle'];
+import { HttpMiddleware } from '../../Http';
 
 export interface RouteDefinition<TRequest extends Request = HttpRequest> {
   name?: string;
   path: string;
   methods: RouterMethod[];
-  handler: RouteDefinitionMiddleware<TRequest>;
-  middleware: RouteDefinitionMiddleware<TRequest>[];
+  handler: HttpMiddleware<TRequest>;
+  middleware: HttpMiddleware<TRequest>[];
   parseBody: boolean;
   bodyOptions: Partial<KoaBodyMiddlewareOptions>;
 }

--- a/src/routing/definition/route-definition.ts
+++ b/src/routing/definition/route-definition.ts
@@ -1,13 +1,18 @@
-import type { HttpMiddleware } from '@/Http';
+import type { HttpRequest, HttpScope, NextMiddleware } from '@/Http';
 import type { RouterMethod } from '@/routing/router-method';
+import type { Request } from 'koa';
 import type { KoaBodyMiddlewareOptions } from 'koa-body';
 
-export interface RouteDefinition {
+type RouteDefinitionMiddleware<TRequest extends Request = HttpRequest> = {
+  handle(scope: HttpScope<TRequest>, next: NextMiddleware): Promise<unknown>;
+}['handle'];
+
+export interface RouteDefinition<TRequest extends Request = HttpRequest> {
   name?: string;
   path: string;
   methods: RouterMethod[];
-  handler: HttpMiddleware;
-  middleware: HttpMiddleware[];
+  handler: RouteDefinitionMiddleware<TRequest>;
+  middleware: RouteDefinitionMiddleware<TRequest>[];
   parseBody: boolean;
   bodyOptions: Partial<KoaBodyMiddlewareOptions>;
 }

--- a/src/routing/definition/route-definition.ts
+++ b/src/routing/definition/route-definition.ts
@@ -1,8 +1,7 @@
-import type { HttpRequest } from '@/Http';
+import type { HttpRequest, HttpMiddleware } from '@/Http';
 import type { RouterMethod } from '@/routing/router-method';
 import type { Request } from 'koa';
 import type { KoaBodyMiddlewareOptions } from 'koa-body';
-import { HttpMiddleware } from '../../Http';
 
 export interface RouteDefinition<TRequest extends Request = HttpRequest> {
   name?: string;

--- a/src/routing/helpers/http-verb-helpers.ts
+++ b/src/routing/helpers/http-verb-helpers.ts
@@ -28,9 +28,16 @@ interface VerbHelperArguments<TRequest extends Request = HttpRequest> {
   handler: RouteHandler<TRequest>;
 }
 
-type NamedVerbHelper<TRequest extends Request = HttpRequest> = {
-  (path: string, ...middlewareAndHandler: MiddlewareAndHandler<TRequest>): RouteDefinition<TRequest>;
-  (path: string, name: string, ...middlewareAndHandler: MiddlewareAndHandler<TRequest>): RouteDefinition<TRequest>;
+type NamedVerbHelper = {
+  <TRequest extends Request = HttpRequest>(
+    path: string,
+    ...middlewareAndHandler: MiddlewareAndHandler<TRequest>
+  ): RouteDefinition<TRequest>;
+  <TRequest extends Request = HttpRequest>(
+    path: string,
+    name: string,
+    ...middlewareAndHandler: MiddlewareAndHandler<TRequest>
+  ): RouteDefinition<TRequest>;
 };
 
 function createVerbHelper(method: HttpMethod): NamedVerbHelper {

--- a/src/routing/helpers/http-verb-helpers.ts
+++ b/src/routing/helpers/http-verb-helpers.ts
@@ -32,12 +32,12 @@ type NamedVerbHelper = {
   <TRequest extends Request = HttpRequest>(
     path: string,
     ...middlewareAndHandler: MiddlewareAndHandler<TRequest>
-  ): RouteDefinition;
+  ): RouteDefinition<TRequest>;
   <TRequest extends Request = HttpRequest>(
     path: string,
     name: string,
     ...middlewareAndHandler: MiddlewareAndHandler<TRequest>
-  ): RouteDefinition;
+  ): RouteDefinition<TRequest>;
 };
 
 function createVerbHelper(method: HttpMethod): NamedVerbHelper {

--- a/src/routing/helpers/http-verb-helpers.ts
+++ b/src/routing/helpers/http-verb-helpers.ts
@@ -28,27 +28,20 @@ interface VerbHelperArguments<TRequest extends Request = HttpRequest> {
   handler: RouteHandler<TRequest>;
 }
 
-type NamedVerbHelper = {
-  <TRequest extends Request = HttpRequest>(
-    path: string,
-    ...middlewareAndHandler: MiddlewareAndHandler<TRequest>
-  ): RouteDefinition<TRequest>;
-  <TRequest extends Request = HttpRequest>(
-    path: string,
-    name: string,
-    ...middlewareAndHandler: MiddlewareAndHandler<TRequest>
-  ): RouteDefinition<TRequest>;
+type NamedVerbHelper<TRequest extends Request = HttpRequest> = {
+  (path: string, ...middlewareAndHandler: MiddlewareAndHandler<TRequest>): RouteDefinition<TRequest>;
+  (path: string, name: string, ...middlewareAndHandler: MiddlewareAndHandler<TRequest>): RouteDefinition<TRequest>;
 };
 
 function createVerbHelper(method: HttpMethod): NamedVerbHelper {
-  return (<TRequest extends Request = HttpRequest>(
+  return <TRequest extends Request = HttpRequest>(
     path: string,
     ...routeArguments: UnsafeVerbHelperRouteArguments<TRequest>
   ) =>
     Route({
       method,
       ...resolveVerbHelperArguments(path, routeArguments),
-    })) as NamedVerbHelper;
+    });
 }
 
 function resolveVerbHelperArguments<TRequest extends Request = HttpRequest>(
@@ -59,7 +52,7 @@ function resolveVerbHelperArguments<TRequest extends Request = HttpRequest>(
   const name = isNamedRoute ? routeArguments[0] : undefined;
   const routeMiddlewareAndHandler = isNamedRoute
     ? (routeArguments.slice(1) as MiddlewareAndHandler<TRequest> | [])
-    : (routeArguments as MiddlewareAndHandler<TRequest> | []);
+    : routeArguments;
   const handler = requireVerbHelperHandler(routeMiddlewareAndHandler, isNamedRoute);
   const middleware = routeMiddlewareAndHandler.slice(0, -1) as HttpMiddleware<TRequest>[];
 

--- a/src/routing/helpers/http-verb-helpers.ts
+++ b/src/routing/helpers/http-verb-helpers.ts
@@ -1,42 +1,67 @@
-import type { HttpMiddleware } from '@/Http';
+import type { HttpMiddleware, HttpRequest } from '@/Http';
 import type { HttpMethod } from '@/routing/http-method';
 import type { RouteDefinition } from '@/routing/definition/route-definition';
 import { Route } from '@/routing/route';
+import type { Request } from 'koa';
 
-type RouteHandler = HttpMiddleware;
-type MiddlewareAndHandler = [...middleware: HttpMiddleware[], handler: RouteHandler];
-type NamedMiddlewareAndHandler = [name: string, ...middlewareAndHandler: MiddlewareAndHandler];
-type VerbHelperRouteArguments = MiddlewareAndHandler | NamedMiddlewareAndHandler;
-type UnsafeVerbHelperRouteArguments = VerbHelperRouteArguments | [name: string] | [];
+type RouteHandler<TRequest extends Request = HttpRequest> = HttpMiddleware<TRequest>;
+type MiddlewareAndHandler<TRequest extends Request = HttpRequest> = [
+  ...middleware: HttpMiddleware<TRequest>[],
+  handler: RouteHandler<TRequest>,
+];
+type NamedMiddlewareAndHandler<TRequest extends Request = HttpRequest> = [
+  name: string,
+  ...middlewareAndHandler: MiddlewareAndHandler<TRequest>,
+];
+type VerbHelperRouteArguments<TRequest extends Request = HttpRequest> =
+  | MiddlewareAndHandler<TRequest>
+  | NamedMiddlewareAndHandler<TRequest>;
+type UnsafeVerbHelperRouteArguments<TRequest extends Request = HttpRequest> =
+  | VerbHelperRouteArguments<TRequest>
+  | [name: string]
+  | [];
 
-interface VerbHelperArguments {
+interface VerbHelperArguments<TRequest extends Request = HttpRequest> {
   path: string;
   name?: string;
-  middleware: HttpMiddleware[];
-  handler: RouteHandler;
+  middleware: HttpMiddleware<TRequest>[];
+  handler: RouteHandler<TRequest>;
 }
 
 type NamedVerbHelper = {
-  (path: string, ...middlewareAndHandler: MiddlewareAndHandler): RouteDefinition;
-  (path: string, name: string, ...middlewareAndHandler: MiddlewareAndHandler): RouteDefinition;
+  <TRequest extends Request = HttpRequest>(
+    path: string,
+    ...middlewareAndHandler: MiddlewareAndHandler<TRequest>
+  ): RouteDefinition;
+  <TRequest extends Request = HttpRequest>(
+    path: string,
+    name: string,
+    ...middlewareAndHandler: MiddlewareAndHandler<TRequest>
+  ): RouteDefinition;
 };
 
 function createVerbHelper(method: HttpMethod): NamedVerbHelper {
-  return (path: string, ...routeArguments: UnsafeVerbHelperRouteArguments) =>
+  return (<TRequest extends Request = HttpRequest>(
+    path: string,
+    ...routeArguments: UnsafeVerbHelperRouteArguments<TRequest>
+  ) =>
     Route({
       method,
       ...resolveVerbHelperArguments(path, routeArguments),
-    });
+    })) as NamedVerbHelper;
 }
 
-function resolveVerbHelperArguments(path: string, routeArguments: UnsafeVerbHelperRouteArguments): VerbHelperArguments {
+function resolveVerbHelperArguments<TRequest extends Request = HttpRequest>(
+  path: string,
+  routeArguments: UnsafeVerbHelperRouteArguments<TRequest>,
+): VerbHelperArguments<TRequest> {
   const isNamedRoute = isNamedVerbHelperRouteArguments(routeArguments);
   const name = isNamedRoute ? routeArguments[0] : undefined;
   const routeMiddlewareAndHandler = isNamedRoute
-    ? (routeArguments.slice(1) as MiddlewareAndHandler | [])
-    : routeArguments;
+    ? (routeArguments.slice(1) as MiddlewareAndHandler<TRequest> | [])
+    : (routeArguments as MiddlewareAndHandler<TRequest> | []);
   const handler = requireVerbHelperHandler(routeMiddlewareAndHandler, isNamedRoute);
-  const middleware = routeMiddlewareAndHandler.slice(0, -1) as HttpMiddleware[];
+  const middleware = routeMiddlewareAndHandler.slice(0, -1) as HttpMiddleware<TRequest>[];
 
   return {
     path,
@@ -46,17 +71,17 @@ function resolveVerbHelperArguments(path: string, routeArguments: UnsafeVerbHelp
   };
 }
 
-function isNamedVerbHelperRouteArguments(
-  routeArguments: UnsafeVerbHelperRouteArguments,
-): routeArguments is NamedMiddlewareAndHandler | [name: string] {
+function isNamedVerbHelperRouteArguments<TRequest extends Request = HttpRequest>(
+  routeArguments: UnsafeVerbHelperRouteArguments<TRequest>,
+): routeArguments is NamedMiddlewareAndHandler<TRequest> | [name: string] {
   return typeof routeArguments[0] === 'string';
 }
 
-function requireVerbHelperHandler(
-  middlewareAndHandler: MiddlewareAndHandler | [],
+function requireVerbHelperHandler<TRequest extends Request = HttpRequest>(
+  middlewareAndHandler: MiddlewareAndHandler<TRequest> | [],
   isNamedRoute: boolean,
-): RouteHandler {
-  const handler = middlewareAndHandler.at(-1) as RouteHandler | undefined;
+): RouteHandler<TRequest> {
+  const handler = middlewareAndHandler.at(-1) as RouteHandler<TRequest> | undefined;
 
   if (handler === undefined && isNamedRoute) {
     throw new Error('Named verb helpers require a handler.');

--- a/src/routing/helpers/route-group.ts
+++ b/src/routing/helpers/route-group.ts
@@ -1,23 +1,27 @@
-import type { HttpMiddleware } from '@/Http';
+import type { HttpMiddleware, HttpRequest } from '@/Http';
 import type { RouteDeclaration } from '@/routing/route';
 import type { RouteSource } from '@/routing/source/route-source';
+import type { Request } from 'koa';
 
 export type RouteConfigOverlay = Pick<RouteDeclaration, 'middleware' | 'options'>;
 
-export interface RouteGroupOptions {
+export interface RouteGroupOptions<TRequest extends Request = HttpRequest> {
   prefix?: string;
   namePrefix?: string;
-  middleware?: HttpMiddleware[];
+  middleware?: HttpMiddleware<TRequest>[];
   routeConfig?: Record<string, RouteConfigOverlay>;
 }
 
-export interface RouteGroupDefinition {
+export interface RouteGroupDefinition<TRequest extends Request = HttpRequest> {
   kind: 'route-group';
-  options: RouteGroupOptions;
-  resolveRoutes: () => RouteSource[];
+  options: RouteGroupOptions<TRequest>;
+  resolveRoutes: () => RouteSource<TRequest>[];
 }
 
-export function RouteGroup(options: RouteGroupOptions, resolveRoutes: () => RouteSource[]): RouteGroupDefinition {
+export function RouteGroup<TRequest extends Request = HttpRequest>(
+  options: RouteGroupOptions<TRequest>,
+  resolveRoutes: () => RouteSource<TRequest>[],
+): RouteGroupDefinition<TRequest> {
   return {
     kind: 'route-group',
     options,

--- a/src/routing/route.ts
+++ b/src/routing/route.ts
@@ -14,10 +14,8 @@ export interface RouteDeclaration<TRequest extends Request = HttpRequest> {
   options?: RouteOptions;
 }
 
-export function Route<TRequest extends Request = HttpRequest>(route: RouteDeclaration<TRequest>): RouteDefinition {
-  return createRouteDefinition({
-    ...route,
-    handler: route.handler as unknown as HttpMiddleware,
-    middleware: route.middleware as unknown as HttpMiddleware[] | undefined,
-  });
+export function Route<TRequest extends Request = HttpRequest>(
+  route: RouteDeclaration<TRequest>,
+): RouteDefinition<TRequest> {
+  return createRouteDefinition(route);
 }

--- a/src/routing/route.ts
+++ b/src/routing/route.ts
@@ -1,18 +1,23 @@
-import type { HttpMiddleware } from '@/Http';
+import type { HttpMiddleware, HttpRequest } from '@/Http';
 import { createRouteDefinition } from '@/routing/definition/create-route-definition';
 import type { RouteDefinition } from '@/routing/definition/route-definition';
 import type { HttpMethod } from '@/routing/http-method';
 import type { RouteOptions } from '@/routing/route-options';
+import type { Request } from 'koa';
 
-export interface RouteDeclaration {
+export interface RouteDeclaration<TRequest extends Request = HttpRequest> {
   name?: string;
   path: string;
   method: HttpMethod | HttpMethod[];
-  handler: HttpMiddleware;
-  middleware?: HttpMiddleware[];
+  handler: HttpMiddleware<TRequest>;
+  middleware?: HttpMiddleware<TRequest>[];
   options?: RouteOptions;
 }
 
-export function Route(route: RouteDeclaration): RouteDefinition {
-  return createRouteDefinition(route);
+export function Route<TRequest extends Request = HttpRequest>(route: RouteDeclaration<TRequest>): RouteDefinition {
+  return createRouteDefinition({
+    ...route,
+    handler: route.handler as unknown as HttpMiddleware,
+    middleware: route.middleware as unknown as HttpMiddleware[] | undefined,
+  });
 }

--- a/src/routing/source/route-source.ts
+++ b/src/routing/source/route-source.ts
@@ -1,4 +1,8 @@
 import type { RouteDefinition } from '@/routing/definition/route-definition';
 import type { RouteGroupDefinition } from '@/routing/helpers/route-group';
+import type { HttpRequest } from '@/Http';
+import type { Request } from 'koa';
 
-export type RouteSource = RouteDefinition | RouteGroupDefinition;
+export type RouteSource<TRequest extends Request = HttpRequest> =
+  | RouteDefinition<TRequest>
+  | RouteGroupDefinition;

--- a/src/routing/source/route-source.ts
+++ b/src/routing/source/route-source.ts
@@ -5,4 +5,4 @@ import type { Request } from 'koa';
 
 export type RouteSource<TRequest extends Request = HttpRequest> =
   | RouteDefinition<TRequest>
-  | RouteGroupDefinition;
+  | RouteGroupDefinition<TRequest>;

--- a/tests/function-first-routing.e2e.test.ts
+++ b/tests/function-first-routing.e2e.test.ts
@@ -252,6 +252,41 @@ describe('Function First Routing E2E Test', () => {
     expect(response.body).toEqual([{ id: 1 }]);
   });
 
+  test('it should register request typed handlers through named verb helpers', async () => {
+    interface CreateSourceRequest extends HttpRequest {
+      body: { name: string };
+      params: { workspaceId: string };
+    }
+    const validateCreateSourceRequest: HttpMiddleware<CreateSourceRequest> = async (_scope, next) => {
+      await next();
+    };
+    const createSourceHandler = async ({ request, response }: HttpScope<CreateSourceRequest>): Promise<void> => {
+      response.body = {
+        name: request.body.name,
+        workspaceId: request.params.workspaceId,
+      };
+    };
+    const agent = createTestAgent({
+      ...koalaDefaultConfig,
+      routes: [
+        Post<CreateSourceRequest>(
+          '/workspaces/:workspaceId/sources',
+          'create',
+          validateCreateSourceRequest,
+          createSourceHandler,
+        ),
+      ],
+    });
+
+    const response = await agent.post('/workspaces/framework/sources').send({ name: 'Koala' });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      name: 'Koala',
+      workspaceId: 'framework',
+    });
+  });
+
   test('it should apply middleware declared through a verb helper in order', async () => {
     const authMiddleware: HttpMiddleware = async (scope: HttpScope, next: NextMiddleware) => {
       scope.response.append('x-middleware-order', 'auth');

--- a/tests/function-first-routing.e2e.test.ts
+++ b/tests/function-first-routing.e2e.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'vitest';
 import { koalaDefaultConfig } from '../src/config/default-config';
 import type { HttpMiddleware, HttpRequest, HttpScope, NextMiddleware, UploadedFile } from '../src/Http';
 import { Any, Get, Post, Route, RouteGroup } from '../src/routing';
-import { createTestAgent } from '../src/Testing';
+import { createTestAgent } from '../src/Testing/TestAgentFactory';
 import { exclusiveRoutingModeError } from '../src/routing/verify-routing-mode';
 
 interface FunctionFirstRoutingRequest extends HttpRequest {
@@ -378,6 +378,7 @@ describe('Function First Routing E2E Test', () => {
                     await next();
                   },
                 ],
+                options: {},
               },
             },
           },
@@ -416,7 +417,10 @@ describe('Function First Routing E2E Test', () => {
           {
             routeConfig: {
               upload: {
-                options: { multipart: true },
+                options: {
+                  multipart: true,
+                },
+                middleware: [],
               },
             },
           },


### PR DESCRIPTION
## Summary

This PR carries the request generic through the function-first route definition APIs so typed route handlers and middleware can be registered without casts.

## Changed has been made: 

- `RouteDefinition<TRequest>` to preserve the request type for route middleware and handlers.
- `createRouteDefinition<TRequest>` to accept typed middleware and handlers and return the typed route definition.
- `Route<TRequest>` to return the same typed route definition it creates.
- HTTP verb helper overloads to return `RouteDefinition<TRequest>` when a request generic is supplied.

## Why

`HttpScope<TRequest>` and `HttpMiddleware<TRequest>` already support typed requests, but the routing registration path erased that type information back to the default `HttpRequest`. As a result, application code like this could not be registered without internal casts:

```ts
Post<CreateSourceRequest>(
  '/workspaces/:workspaceId/sources',
  'create',
  validateCreateSourceRequest,
  createSourceHandler,
);
```

This change aligns the function-first routing API with the existing request-generic HTTP types.



| Q       | A                      |
| ------- | ---------------------- |
| License | GPLv3                  |
| Issue   | Closes #183  > |