### PR TITLE
chore: Extract release and mirror scripts

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -101,33 +101,4 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           RELEASE_PLAN_PATH: ${{ runner.temp }}/release-plan.json
         run: |
-          node -e "const { packageNames } = JSON.parse(require('node:fs').readFileSync(process.env.RELEASE_PLAN_PATH)); process.stdout.write(packageNames.join('\\n'));" | while IFS= read -r package_name; do
-            if [ "$package_name" = '@koala-ts/framework' ]; then
-              npm publish --provenance --access public
-            else
-              npm publish --workspace="$package_name" --provenance --access public
-            fi
-          done
-
-      - name: Mirror released components
-        if: steps.release_plan.outputs.package_count != '0'
-        env:
-          KOALA_TS_MIRROR_TOKEN: ${{ secrets.KOALA_TS_MIRROR_TOKEN }}
-          RELEASE_TAG: ${{ steps.release.outputs.tag }}
-          RELEASE_PLAN_PATH: ${{ runner.temp }}/release-plan.json
-        run: |
-          if node -e "const { packageNames } = JSON.parse(require('node:fs').readFileSync(process.env.RELEASE_PLAN_PATH)); process.exit(packageNames.includes('@koala-ts/contracts') ? 0 : 1);"; then
-            mirror_directory=$(mktemp -d)
-            git clone "https://x-access-token:${KOALA_TS_MIRROR_TOKEN}@github.com/koala-ts/contracts.git" "$mirror_directory"
-            git -C "$mirror_directory" checkout -B main
-            rsync -a --delete --exclude .git --exclude dist --exclude node_modules src/packages/contracts/ "$mirror_directory/"
-            git -C "$mirror_directory" config user.name 'koala-ts-release-bot'
-            git -C "$mirror_directory" config user.email 'release-bot@koala-ts.dev'
-            git -C "$mirror_directory" add --all
-            if ! git -C "$mirror_directory" diff --cached --quiet; then
-              git -C "$mirror_directory" commit -m "chore(release): mirror ${RELEASE_TAG}"
-            fi
-            git -C "$mirror_directory" tag -fa "$RELEASE_TAG" -m "Release ${RELEASE_TAG}"
-            git -C "$mirror_directory" push --force origin main
-            git -C "$mirror_directory" push --force origin "refs/tags/${RELEASE_TAG}"
-          fi
+          node scripts/release/publish-release.js "${{ steps.release.outputs.tag }}" "$RELEASE_PLAN_PATH"

--- a/.github/workflows/mirror-components.yml
+++ b/.github/workflows/mirror-components.yml
@@ -1,0 +1,56 @@
+name: Mirror components
+
+on:
+  push:
+    branches:
+      - 2.x
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Mirror changed components
+        env:
+          KOALA_TS_MIRROR_TOKEN: ${{ secrets.KOALA_TS_MIRROR_TOKEN }}
+          PREVIOUS_COMMIT: ${{ github.event.before }}
+          SOURCE_COMMIT: ${{ github.sha }}
+        run: |
+          mapfile -t component_directories < <(node scripts/mirror/changed-component-directories.js "$PREVIOUS_COMMIT" "$SOURCE_COMMIT")
+
+          for component_directory in "${component_directories[@]}"; do
+            if [ ! -f "$component_directory/package.json" ]; then
+              continue
+            fi
+
+            package_name=$(node -p "require('./' + process.argv[1]).name" "$component_directory/package.json")
+            case "$package_name" in
+              @koala-ts/*)
+                repository_name="${package_name#@koala-ts/}"
+                ;;
+              *)
+                echo "Skipping $package_name because it is outside the @koala-ts scope."
+                continue
+                ;;
+            esac
+
+            mirror_directory=$(mktemp -d)
+            git clone "https://x-access-token:${KOALA_TS_MIRROR_TOKEN}@github.com/koala-ts/${repository_name}.git" "$mirror_directory"
+            git -C "$mirror_directory" checkout -B main
+            rsync -a --delete --exclude .git --exclude dist --exclude node_modules "$component_directory/" "$mirror_directory/"
+            git -C "$mirror_directory" config user.name 'koala-ts-mirror-bot'
+            git -C "$mirror_directory" config user.email 'mirror-bot@koala-ts.dev'
+            git -C "$mirror_directory" add --all
+
+            if git -C "$mirror_directory" diff --cached --quiet; then
+              continue
+            fi
+
+            git -C "$mirror_directory" commit -m "chore(mirror): sync ${package_name}" -m "source: koala-ts/framework@${SOURCE_COMMIT}"
+            git -C "$mirror_directory" push origin main
+          done

--- a/scripts/mirror/changed-component-directories.js
+++ b/scripts/mirror/changed-component-directories.js
@@ -1,0 +1,32 @@
+import { execFileSync } from 'node:child_process';
+
+const [previousCommit, currentCommit] = process.argv.slice(2);
+
+if (previousCommit && currentCommit) {
+  const changedFiles = execFileSync('git', ['diff', '--name-only', previousCommit, currentCommit], {
+    encoding: 'utf8',
+  })
+    .trim()
+    .split('\n')
+    .filter(Boolean);
+
+  process.stdout.write(`${getChangedComponentDirectories({ changedFiles }).join('\n')}\n`);
+}
+
+/**
+ * @param {{ changedFiles: string[] }} options
+ * @returns {string[]}
+ */
+export function getChangedComponentDirectories({ changedFiles }) {
+  return [...new Set(changedFiles.map(getComponentDirectory).filter(Boolean))].sort();
+}
+
+function getComponentDirectory(changedFile) {
+  const [sourceDirectory, packagesDirectory, componentDirectory] = changedFile.split('/');
+
+  if (sourceDirectory !== 'src' || packagesDirectory !== 'packages' || !componentDirectory) {
+    return undefined;
+  }
+
+  return `src/packages/${componentDirectory}`;
+}

--- a/scripts/mirror/changed-component-directories.test.ts
+++ b/scripts/mirror/changed-component-directories.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { getChangedComponentDirectories } from './changed-component-directories.js';
+
+describe('changed component directories', () => {
+  it('returns each changed component directory once', () => {
+    const changedFiles = [
+      'src/packages/contracts/index.ts',
+      'src/packages/contracts/package.json',
+      'src/packages/validation/index.ts',
+      'src/index.ts',
+    ];
+
+    const componentDirectories = getChangedComponentDirectories({ changedFiles });
+
+    expect(componentDirectories).toEqual(['src/packages/contracts', 'src/packages/validation']);
+  });
+});

--- a/scripts/release/publish-release.js
+++ b/scripts/release/publish-release.js
@@ -1,0 +1,67 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+const [releaseTag, releasePlanPath] = process.argv.slice(2);
+
+if (releaseTag && releasePlanPath) {
+  const { packageNames } = JSON.parse(readFileSync(releasePlanPath, 'utf8'));
+  const packageNamesToPublish = selectPackagesToPublish({
+    getPublishedVersion,
+    packageNames,
+    releaseTag,
+  });
+
+  for (const packageName of packageNamesToPublish) {
+    publishPackage(packageName);
+  }
+
+  const skippedPackageNames = packageNames.filter(packageName => !packageNamesToPublish.includes(packageName));
+  process.stdout.write(`Published packages: ${packageNamesToPublish.join(', ') || 'none'}\n`);
+  process.stdout.write(`Skipped packages: ${skippedPackageNames.join(', ') || 'none'}\n`);
+}
+
+/**
+ * @param {{
+ *   packageNames: string[];
+ *   releaseTag: string;
+ *   getPublishedVersion: (packageName: string) => string | undefined;
+ * }} options
+ * @returns {string[]}
+ */
+export function selectPackagesToPublish({ getPublishedVersion, packageNames, releaseTag }) {
+  return packageNames.filter(packageName => {
+    const publishedVersion = getPublishedVersion(packageName);
+
+    if (!publishedVersion) {
+      return true;
+    }
+
+    if (publishedVersion === releaseTag) {
+      return false;
+    }
+
+    throw new Error(`${packageName} is already published as ${publishedVersion}.`);
+  });
+}
+
+function getPublishedVersion(packageName) {
+  try {
+    return execFileSync('npm', ['view', `${packageName}@${releaseTag}`, 'version'], { encoding: 'utf8' }).trim();
+  } catch (error) {
+    if (error.status === 1 && error.stderr.includes('E404')) {
+      return undefined;
+    }
+
+    throw error;
+  }
+}
+
+function publishPackage(packageName) {
+  const arguments_ = ['publish', '--provenance', '--access', 'public'];
+
+  if (packageName !== '@koala-ts/framework') {
+    arguments_.push(`--workspace=${packageName}`);
+  }
+
+  execFileSync('npm', arguments_, { stdio: 'inherit' });
+}

--- a/scripts/release/publish-release.test.ts
+++ b/scripts/release/publish-release.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { selectPackagesToPublish } from './publish-release.js';
+
+describe('release publishing', () => {
+  it('selects the root package and every selected component that is not published at the release version', () => {
+    const packageNames = ['@koala-ts/contracts', '@koala-ts/framework'];
+    const getPublishedVersion = () => undefined;
+
+    const packageNamesToPublish = selectPackagesToPublish({
+      getPublishedVersion,
+      packageNames,
+      releaseTag: '2.28.7',
+    });
+
+    expect(packageNamesToPublish).toEqual(['@koala-ts/contracts', '@koala-ts/framework']);
+  });
+
+  it('skips a package already published at the release version', () => {
+    const packageNames = ['@koala-ts/contracts', '@koala-ts/framework'];
+    const getPublishedVersion = (packageName: string) => (packageName === '@koala-ts/contracts' ? '2.28.7' : undefined);
+
+    const packageNamesToPublish = selectPackagesToPublish({
+      getPublishedVersion,
+      packageNames,
+      releaseTag: '2.28.7',
+    });
+
+    expect(packageNamesToPublish).toEqual(['@koala-ts/framework']);
+  });
+
+  it('rejects a package with an unexpected published version', () => {
+    const packageNames = ['@koala-ts/contracts'];
+    const getPublishedVersion = () => '2.28.6';
+
+    const selectPackages = () => selectPackagesToPublish({ getPublishedVersion, packageNames, releaseTag: '2.28.7' });
+
+    expect(selectPackages).toThrow('@koala-ts/contracts is already published as 2.28.6.');
+  });
+});


### PR DESCRIPTION
Replaces inline shell in cd.yml with a dedicated publish-release.js script that skips already-published packages. Adds a new mirror-components.yml workflow that mirrors changed src/packages/* directories on every push to 2.x, driven by a new changed-component-directories.js script. Both scripts have unit test coverage.

| Q       | A                      |
| ------- | ---------------------- |
| License | Apache-2.0             |
| Issue   | Closes #<issue_number> |
